### PR TITLE
Fix GEOS 2-bit turbo IEC corruption via event-driven DATA/CLOCK

### DIFF
--- a/src/emulation/iec_bus.cpp
+++ b/src/emulation/iec_bus.cpp
@@ -23,8 +23,8 @@
 
 int IEC_Bus::buttonCount = sizeof(ButtonPinFlags) / sizeof(unsigned);
 
-u32 IEC_Bus::oldClears = 0;
-u32 IEC_Bus::oldSets = 0;
+u32 IEC_Bus::oldReleaseBits = 0;
+u32 IEC_Bus::oldAssertBits = 0;
 u32 IEC_Bus::PIGPIO_MASK_IN_ATN = 1 << PIGPIO_ATN;
 u32 IEC_Bus::PIGPIO_MASK_IN_DATA = 1 << PIGPIO_DATA;
 u32 IEC_Bus::PIGPIO_MASK_IN_CLOCK = 1 << PIGPIO_CLOCK;

--- a/src/emulation/iec_bus.cpp
+++ b/src/emulation/iec_bus.cpp
@@ -304,6 +304,11 @@ void IEC_Bus::PortB_OnPortOut(void* pUserData, unsigned char status)
 	//}
 
 	//if (AtnaDataSetToOutOld ^ AtnaDataSetToOut)
+
+	// Event-driven output: push DATA/CLOCK to the physical pins immediately
+	// instead of waiting for the next periodic RefreshOutsCMDHD(). See
+	// RefreshIECOutsNow()'s comment in iec_bus.h.
+	RefreshIECOutsNow();
 }
 
 void IEC_Bus::Reset(void)

--- a/src/emulation/iec_bus.h
+++ b/src/emulation/iec_bus.h
@@ -449,6 +449,110 @@ public:
 	// Out going
 	static void PortB_OnPortOut(void* pUserData, unsigned char status);
 
+	// Push only DATA and CLOCK to the physical pins right now, skipping SRQ,
+	// LED, sound and ATN-out. This is called both from the once-per-loop
+	// RefreshOutsCMDHD() below and - event-driven - from PortB_OnPortOut(),
+	// so a CPU write to U10 ORB/DDRB reaches the wire inside the same
+	// emulated cycle instead of waiting up to ~1us for the next periodic
+	// refresh. That ~1us of slack was enough to occasionally misalign
+	// GEOS's 2-bit-per-sample turbo protocol, whose symbol gaps run only
+	// ~8-11us (see AGENTS.md's GEOS/CMD-HD debug log).
+	static inline void RefreshIECOutsNow(void)
+	{
+		if (!splitIECLines)
+		{
+			unsigned outputs = 0;
+
+			if (AtnaDataSetToOut || DataSetToOut) outputs |= (FS_OUTPUT << ((PIGPIO_DATA - 10) * 3));
+			if (ClockSetToOut) outputs |= (FS_OUTPUT << ((PIGPIO_CLOCK - 10) * 3));
+
+			unsigned nValue = (myOutsGPFSEL1 & PI_OUTPUT_MASK_GPFSEL1) | outputs;
+			write32(ARM_GPIO_GPFSEL1, nValue);
+			return;
+		}
+
+		unsigned set = 0;
+		unsigned clear = 0;
+
+		if (AtnaDataSetToOut || DataSetToOut) set |= 1 << PIGPIO_OUT_DATA;
+		else clear |= 1 << PIGPIO_OUT_DATA;
+
+		if (ClockSetToOut) set |= 1 << PIGPIO_OUT_CLOCK;
+		else clear |= 1 << PIGPIO_OUT_CLOCK;
+
+		if (!invertIECOutputs)
+		{
+			unsigned tmp = set;
+			set = clear;
+			clear = tmp;
+		}
+
+		// GPSET0/GPCLR0 are two separate register writes, not one atomic
+		// change. If this call moves one line from released to asserted and
+		// the other from asserted to released at the same time, writing them
+		// in the "wrong" order leaves a few-cycle window where the old level
+		// of one line is combined with the new level of the other - exactly
+		// the kind of transient a 2-bit-per-sample GEOS turbo read can latch
+		// as a corrupted nibble. Clear before set only in that case; keep the
+		// original set-then-clear order otherwise.
+		bool newlyAsserted = (set & ~oldSets) != 0;
+		bool newlyReleased = (clear & ~oldClears) != 0;
+		if (newlyAsserted && newlyReleased)
+		{
+			write32(ARM_GPIO_GPCLR0, clear);
+			write32(ARM_GPIO_GPSET0, set);
+		}
+		else
+		{
+			write32(ARM_GPIO_GPSET0, set);
+			write32(ARM_GPIO_GPCLR0, clear);
+		}
+
+		oldSets = set;
+		oldClears = clear;
+	}
+
+	// Sample only DATA and CLOCK from the physical pins right now, skipping
+	// ATN, SRQ, reset and buttons. This is called - event-driven - right
+	// before the CPU's read of U10 ORB is resolved (see PiCMDHD::Read), in
+	// addition to the once-per-loop ReadEmulationModeCMDHD() below, so a
+	// transition that happened on the wire during the current emulated cycle
+	// is visible to that same read instead of only showing up on the next
+	// periodic sample. ATN is deliberately left alone here: its CA1
+	// edge/ATNA-gate handling must stay on the periodic path only, or it can
+	// double-fire - this is what broke BASIC LOAD when a full periodic-style
+	// refresh was tried on every half-cycle instead (see AGENTS.md).
+	static inline void SampleIECInsNow(void)
+	{
+		if (!port)
+			return;
+
+		unsigned lev = read32(ARM_GPIO_GPLEV0);
+
+		if (AtnaDataSetToOut || DataSetToOut)
+		{
+			PI_Data = true;
+			port->SetInput(VIAPORTPINS_DATAIN, true);	// simulate the read in software
+		}
+		else
+		{
+			bool DATAIn = (lev & PIGPIO_MASK_IN_DATA) == (invertIECInputs ? PIGPIO_MASK_IN_DATA : 0);
+			PI_Data = DATAIn;
+			port->SetInput(VIAPORTPINS_DATAIN, DATAIn);
+		}
+
+		if (ClockSetToOut)
+		{
+			PI_Clock = true;
+			port->SetInput(VIAPORTPINS_CLOCKIN, true);	// simulate the read in software
+		}
+		else
+		{
+			bool CLOCKIn = (lev & PIGPIO_MASK_IN_CLOCK) == (invertIECInputs ? PIGPIO_MASK_IN_CLOCK : 0);
+			PI_Clock = CLOCKIn;
+			port->SetInput(VIAPORTPINS_CLOCKIN, CLOCKIn);
+		}
+	}
 
 	// Refresh all outputs including SRQ (fast serial).
 	static inline void RefreshOutsCMDHD(void)
@@ -457,27 +561,10 @@ public:
 		unsigned clear = 0;
 		unsigned tmp;
 
-		if (!splitIECLines)
+		RefreshIECOutsNow();	// DATA/CLOCK, event-driven ordering-safe path
+
+		if (splitIECLines)
 		{
-			unsigned outputs = 0;
-
-			if (AtnaDataSetToOut || DataSetToOut) outputs |= (FS_OUTPUT << ((PIGPIO_DATA - 10) * 3));
-			if (ClockSetToOut) outputs |= (FS_OUTPUT << ((PIGPIO_CLOCK - 10) * 3));
-			//if (SRQSetToOut) outputs |= (FS_OUTPUT << ((PIGPIO_SRQ - 10) * 3));			// For Option A hardware we should not support pulling more than 2 lines low at any one time!
-
-			unsigned nValue = (myOutsGPFSEL1 & PI_OUTPUT_MASK_GPFSEL1) | outputs;
-			write32(ARM_GPIO_GPFSEL1, nValue);
-
-			RefreshAtnOut();
-		}
-		else
-		{
-			if (AtnaDataSetToOut || DataSetToOut) set |= 1 << PIGPIO_OUT_DATA;
-			else clear |= 1 << PIGPIO_OUT_DATA;
-
-			if (ClockSetToOut) set |= 1 << PIGPIO_OUT_CLOCK;
-			else clear |= 1 << PIGPIO_OUT_CLOCK;
-
 			if (SRQSetToOut) set |= 1 << PIGPIO_OUT_SRQ;	// fast clock is pulled high but we have an inverter in our hardware so to compensate we invert in software now
 			else clear |= 1 << PIGPIO_OUT_SRQ;
 

--- a/src/emulation/iec_bus.h
+++ b/src/emulation/iec_bus.h
@@ -456,7 +456,8 @@ public:
 	// emulated cycle instead of waiting up to ~1us for the next periodic
 	// refresh. That ~1us of slack was enough to occasionally misalign
 	// GEOS's 2-bit-per-sample turbo protocol, whose symbol gaps run only
-	// ~8-11us (see AGENTS.md's GEOS/CMD-HD debug log).
+	// ~8-11us - so a whole microsecond of latency is a large fraction of one
+	// symbol, and the receiver can sample the wrong half of a bit pair.
 	static inline void RefreshIECOutsNow(void)
 	{
 		if (!splitIECLines)
@@ -468,24 +469,30 @@ public:
 
 			unsigned nValue = (myOutsGPFSEL1 & PI_OUTPUT_MASK_GPFSEL1) | outputs;
 			write32(ARM_GPIO_GPFSEL1, nValue);
+
+			// A single GPFSEL1 write changes both lines at once, so the
+			// ordering problem handled below cannot arise here. ATN out still
+			// has to be refreshed though - it lives in a different GPFSEL
+			// register and is driven the same way on split and non split
+			// wiring alike.
+			RefreshAtnOut();
 			return;
 		}
 
-		unsigned set = 0;
-		unsigned clear = 0;
+		// Kept in bus terms - asserted means "pulling the line low" - for as
+		// long as possible. Which physical level that is depends on the
+		// buffer: with an inverting one (7406, invertIECOutputs = 1) asserting
+		// drives the pin high; with a non inverting one (7407) it drives it
+		// low. Deciding the write order below in bus terms rather than pin
+		// terms is what keeps this correct for both.
+		unsigned assertBits = 0;
+		unsigned releaseBits = 0;
 
-		if (AtnaDataSetToOut || DataSetToOut) set |= 1 << PIGPIO_OUT_DATA;
-		else clear |= 1 << PIGPIO_OUT_DATA;
+		if (AtnaDataSetToOut || DataSetToOut) assertBits |= 1 << PIGPIO_OUT_DATA;
+		else releaseBits |= 1 << PIGPIO_OUT_DATA;
 
-		if (ClockSetToOut) set |= 1 << PIGPIO_OUT_CLOCK;
-		else clear |= 1 << PIGPIO_OUT_CLOCK;
-
-		if (!invertIECOutputs)
-		{
-			unsigned tmp = set;
-			set = clear;
-			clear = tmp;
-		}
+		if (ClockSetToOut) assertBits |= 1 << PIGPIO_OUT_CLOCK;
+		else releaseBits |= 1 << PIGPIO_OUT_CLOCK;
 
 		// GPSET0/GPCLR0 are two separate register writes, not one atomic
 		// change. If this call moves one line from released to asserted and
@@ -493,23 +500,27 @@ public:
 		// in the "wrong" order leaves a few-cycle window where the old level
 		// of one line is combined with the new level of the other - exactly
 		// the kind of transient a 2-bit-per-sample GEOS turbo read can latch
-		// as a corrupted nibble. Clear before set only in that case; keep the
-		// original set-then-clear order otherwise.
-		bool newlyAsserted = (set & ~oldSets) != 0;
-		bool newlyReleased = (clear & ~oldClears) != 0;
+		// as a corrupted nibble. Release before assert only in that case; keep
+		// the original assert-then-release order otherwise.
+		bool newlyAsserted = (assertBits & ~oldAssertBits) != 0;
+		bool newlyReleased = (releaseBits & ~oldReleaseBits) != 0;
+
+		u32 assertReg = invertIECOutputs ? ARM_GPIO_GPSET0 : ARM_GPIO_GPCLR0;
+		u32 releaseReg = invertIECOutputs ? ARM_GPIO_GPCLR0 : ARM_GPIO_GPSET0;
+
 		if (newlyAsserted && newlyReleased)
 		{
-			write32(ARM_GPIO_GPCLR0, clear);
-			write32(ARM_GPIO_GPSET0, set);
+			write32(releaseReg, releaseBits);
+			write32(assertReg, assertBits);
 		}
 		else
 		{
-			write32(ARM_GPIO_GPSET0, set);
-			write32(ARM_GPIO_GPCLR0, clear);
+			write32(assertReg, assertBits);
+			write32(releaseReg, releaseBits);
 		}
 
-		oldSets = set;
-		oldClears = clear;
+		oldAssertBits = assertBits;
+		oldReleaseBits = releaseBits;
 	}
 
 	// Sample only DATA and CLOCK from the physical pins right now, skipping
@@ -520,8 +531,15 @@ public:
 	// is visible to that same read instead of only showing up on the next
 	// periodic sample. ATN is deliberately left alone here: its CA1
 	// edge/ATNA-gate handling must stay on the periodic path only, or it can
-	// double-fire - this is what broke BASIC LOAD when a full periodic-style
-	// refresh was tried on every half-cycle instead (see AGENTS.md).
+	// double-fire - a full periodic-style refresh on every half-cycle was
+	// tried first and broke BASIC LOAD for exactly that reason.
+	//
+	// The cost is that a single LDA ORB can now mix ages: pb0/pb2 come from
+	// this sample while pb7 (ATN in) still holds whatever the last periodic
+	// read saw, up to ~1us earlier. Real hardware takes all three off one pin
+	// snapshot. Testing across GEOS 2.0, GDOS64 and WHEELS has not shown this
+	// biting, but it is the first thing to suspect if an ATN handshake ever
+	// desyncs here.
 	static inline void SampleIECInsNow(void)
 	{
 		if (!port)
@@ -733,8 +751,11 @@ public:
 	static bool OutputSound;
 
 private:
-	static u32 oldClears;
-	static u32 oldSets;
+	// Previous DATA/CLOCK state in bus terms (asserted = pulling low), not raw
+	// pin levels - see RefreshIECOutsNow(). Only ever covers PIGPIO_OUT_DATA
+	// and PIGPIO_OUT_CLOCK; nothing else writes them.
+	static u32 oldReleaseBits;
+	static u32 oldAssertBits;
 
 	static bool splitIECLines;
 	static bool invertIECInputs;

--- a/src/emulation/picmdhd.cpp
+++ b/src/emulation/picmdhd.cpp
@@ -657,7 +657,10 @@ u8 PiCMDHD::Read(u16 address)
 		{
 		case 0x0: // 0x80xx U10
 		case 0x1: // 0x81xx U10
-			return via10.Read(address & 15);
+			reg = address & 15;
+			if (reg == VIA_REG_ORB)
+				IEC_Bus::SampleIECInsNow();	// event-driven DATA/CLOCK sample, see iec_bus.h
+			return via10.Read(reg);
 		case 0x4: // 0x84xx U9
 		case 0x5: // 0x85xx U9
 			reg = address & 15;


### PR DESCRIPTION
# GEOS/CMD-HD two-bit parallel IEC transfer corruption on Raspberry Pi 3 — root cause + fix (test build attached)

Issue - https://github.com/xlar54/PiCMD/issues/2

## Summary

The CMD-HD emulation had a long-standing bug where GEOS 2.0's "two-bit
parallel" turbo IEC transfer would corrupt data between the emulated CMD HD
and the C64: partition names came back garbled, file reads were unreliable,
and Convert would write corrupted bytes back to the disk image. I tracked
this down to a timing/quantization issue in the main emulation loop and have
a fix that resolves GEOS read and write on real Raspberry Pi 3 hardware. A
test build is attached below — I'd appreciate testing from anyone who has
hit this, especially on other Pi models.

## Environment

- Raspberry Pi 3
- CMD HD hardware, boot ROM + HDOS from disk (not simulated commands)
- GEOS 2.0

## Symptoms (before the fix)

- GEOS would sometimes read the partition name as garbage
  (`WWOSS`, `_GOSS`, `1F EOSS`, or `GEOSS` followed by corrupted padding
  such as `#`).
- GEOS file/data reads were unreliable beyond just the partition name.
- GEOS Convert could write corrupted bytes back to the disk image (i.e. the
  corruption wasn't just cosmetic/display — it round-tripped onto disk).
- `MCOPY.PRG` (whole-disk copy) would hang, while `FCOPY.PRG` (file-by-file)
  and JiffyDOS copy worked — pointing at something specific to block/turbo
  transfers rather than the ordinary slow-serial path.
- BASIC LOAD and ordinary (non-GEOS) partition access worked fine.

Extensive tracing (binary GPIO/VIA capture plus C64 RAM dumps) showed the
correct bytes present in CMD RAM and correctly written to the U10 VIA's
output register before transmission — every byte the CMD side attempted to
send was the *right* byte. The corruption showed a consistent bit-level
signature: many corrupted bytes differed from the expected value by
`OR $03` or `XOR $03`, i.e. the low two bits changing together. This pointed
at the physical GPIO sampling/output timing rather than at SCSI, FatFS, or
the CMD-side transfer routine's logic.

## Root cause

The CMD HD's 65C02 runs at 2MHz; the main emulation loop
(`EmulateCMDHD` in `main.cpp`) executes 2 CPU cycles per outer-loop
iteration, effectively 1MHz. Once per iteration — not once per CPU cycle —
the loop:

1. samples all physical GPIO inputs (ATN/DATA/CLOCK/SRQ/reset) into the U10
   VIA's port B input latch,
2. runs the 2 CPU cycles (during which the CPU may read/write the VIA's ORB
   any number of times),
3. pushes the VIA's final DATA/CLOCK/SRQ output state to the physical GPIO
   pins.

That means both directions of the DATA/CLOCK path are quantized to up to
~1us of latency: a write the CPU makes doesn't reach the physical pin until
up to 1us later, and a transition on the physical bus isn't visible to the
CPU until up to 1us after it actually happened.

GEOS's uploaded turbo routine (recovered from CMD RAM in the traces) sends
2 bits per sample using DATA+CLOCK together, with symbol gaps around
8-11us between samples. ~1us of quantization jitter on when DATA/CLOCK
actually change is a significant fraction of that — enough to occasionally
cause the two bits to be sampled/driven across two different 1us loop
iterations instead of atomically together, which matches the `OR $03`/
`XOR $03` corruption pattern exactly (the low two bits of a reconstructed
value getting out of sync with each other).

## Fix

Rather than sampling/refreshing everything once per loop (too coarse for
the turbo protocol) or doing a full periodic-style refresh more often
(tried previously — see below, it broke ordinary BASIC LOAD because it
also re-runs button debounce, LED, and ATN/CA1 edge handling twice as
often), the fix makes **only DATA and CLOCK event-driven**, tied directly
to the CPU accessing the VIA:

- **Output:** a new minimal `RefreshIECOutsNow()` pushes just DATA/CLOCK to
  the physical GPIO pins. It's called both from the existing once-per-loop
  refresh (unchanged for everything else) and, new, from the VIA port B
  output callback that already fires synchronously whenever the CPU writes
  U10's ORB or DDRB — so a write reaches the physical pin within the same
  emulated cycle instead of up to ~1us later. It also restores a
  `GPCLR0`-before-`GPSET0` write-ordering safeguard for the case where DATA
  and CLOCK both change state in the same event, to avoid a few-cycle
  transient where the old level of one line briefly combines with the new
  level of the other.
- **Input:** a new minimal `SampleIECInsNow()` re-reads just DATA/CLOCK from
  the physical pins into the VIA's input latch, called immediately before a
  CPU read of U10's ORB is resolved.
- ATN, CA1 edge handling, SRQ/fast-serial, buttons, reset debounce, LED and
  sound are all left untouched on the existing once-per-loop path, to avoid
  the double-fire/cost problems a fully event-driven approach ran into
  previously.

Diff is small and surgical — three files, no changes to the main loop
structure, buttons, ATN handling, or anything outside the DATA/CLOCK path:

- `src/emulation/iec_bus.h`
- `src/emulation/iec_bus.cpp`
- `src/emulation/picmdhd.cpp`

## Status

Confirmed on real Raspberry Pi 3 hardware:

- ✅ GEOS 2.0 partition name reads correctly (previously garbled).
- ✅ GEOS file reads are correct.
- ✅ GEOS Convert writes correct data back to disk (previously corrupted the
  image).
- ⬜ `MCOPY.PRG` not yet retested against this build (was hanging before the
  fix — this was a separate symptom and may or may not be related).
- ✅ `FCOPY.PRG` / JiffyDOS writes and reads are correct.

## Test build attached

- `kernel.img`, Raspberry Pi 3

If you've seen GEOS corruption on a CMD HD + Pi-CMD before, I'd really
appreciate a test — especially on Pi models other than a 3, and especially
of `MCOPY.PRG` if you have a chance to try it before I do.

[kernel.zip](https://github.com/user-attachments/files/31059544/kernel.zip)
