### PR TITLE
Fix file browser buttons becoming unresponsive after CMD HD emulation

### DIFF
--- a/src/emulation/iec_bus.cpp
+++ b/src/emulation/iec_bus.cpp
@@ -69,6 +69,7 @@ u32 IEC_Bus::validInputCount[5] = { 0 };
 u32 IEC_Bus::inputRepeatThreshold[5];
 u32 IEC_Bus::inputRepeat[5] = { 0 };
 u32 IEC_Bus::inputRepeatPrev[5] = { 0 };
+u32 IEC_Bus::pressStartTime[5] = { 0 };
 
 
 u32 IEC_Bus::emulationModeCheckButtonIndex = 0;

--- a/src/emulation/iec_bus.cpp
+++ b/src/emulation/iec_bus.cpp
@@ -65,7 +65,7 @@ u32 IEC_Bus::myOutsGPFSEL1 = 0;
 u32 IEC_Bus::myOutsGPFSEL0 = 0;
 bool IEC_Bus::InputButton[5] = { 0 };
 bool IEC_Bus::InputButtonPrev[5] = { 0 };
-u32 IEC_Bus::validInputCount[5] = { 0 };
+bool IEC_Bus::buttonPressed[5] = { 0 };
 u32 IEC_Bus::inputRepeatThreshold[5];
 u32 IEC_Bus::inputRepeat[5] = { 0 };
 u32 IEC_Bus::inputRepeatPrev[5] = { 0 };
@@ -78,9 +78,14 @@ unsigned IEC_Bus::gplev0;
 
 void IEC_Bus::ReadGPIOUserInput()
 {
+	// One timer read for all the buttons - see UpdateButton's comment. This is
+	// on the ~1MHz emulation path, where an uncached peripheral read per button
+	// would be five times the cost for no benefit.
+	u32 nowUs = read32(ARM_SYSTIMER_CLO);
+
 	for (int index = 0; index < buttonCount; ++index)
 	{
-		UpdateButton(index, gplev0);
+		UpdateButton(index, gplev0, nowUs);
 	}
 }
 

--- a/src/emulation/iec_bus.h
+++ b/src/emulation/iec_bus.h
@@ -359,7 +359,7 @@ public:
 		{
 			InputButton[index] = false;
 			InputButtonPrev[index] = false;
-			validInputCount[index] = 0;
+			buttonPressed[index] = false;
 			inputRepeatThreshold[index] = INPUT_BUTTON_REPEAT_THRESHOLD;
 			inputRepeat[index] = 0;
 			inputRepeatPrev[index] = 0;
@@ -401,9 +401,20 @@ public:
 	// never accumulated anywhere near 20000 *calls* and buttons appeared
 	// completely unresponsive while browsing. Using elapsed time instead
 	// makes the debounce feel the same regardless of which loop is calling
-	// it. See AGENTS.md's "File Browser Button Unresponsive After Emulation"
-	// note for how this was diagnosed.
-	static void UpdateButton(int index, unsigned gplev0)
+	// it.
+	//
+	// nowUs is passed in rather than read here: this runs once per button per
+	// call of ReadGPIOUserInput(), and in emulation mode that is the ~1MHz
+	// loop, which otherwise touches no system timer register at all. Reading
+	// ARM_SYSTIMER_CLO is an uncached peripheral access, so sampling it once
+	// for all five buttons keeps it off the per-button path - and gives every
+	// button a consistent timestamp, which is marginally more correct too.
+	//
+	// The subtraction below is deliberately unsigned: ARM_SYSTIMER_CLO is the
+	// low 32 bits of the 1MHz counter and wraps every ~71.6 minutes, and u32
+	// wraparound makes the elapsed time come out right across that boundary.
+	// It looks like a bug and is not - please leave it alone.
+	static void UpdateButton(int index, unsigned gplev0, u32 nowUs)
 	{
 		bool inputcurrent = (gplev0 & ButtonPinFlags[index]) == 0;
 
@@ -412,11 +423,13 @@ public:
 
 		if (inputcurrent)
 		{
-			if (validInputCount[index] == 0)
-				pressStartTime[index] = read32(ARM_SYSTIMER_CLO);	// start of this press streak
-			validInputCount[index]++;
+			if (!buttonPressed[index])
+			{
+				buttonPressed[index] = true;
+				pressStartTime[index] = nowUs;		// start of this press streak
+			}
 
-			u32 heldUs = read32(ARM_SYSTIMER_CLO) - pressStartTime[index];
+			u32 heldUs = nowUs - pressStartTime[index];
 
 			if (!InputButton[index] && heldUs >= INPUT_BUTTON_DEBOUNCE_THRESHOLD)
 			{
@@ -434,7 +447,7 @@ public:
 		else
 		{
 			InputButton[index] = false;
-			validInputCount[index] = 0;
+			buttonPressed[index] = false;
 			inputRepeatThreshold[index] = INPUT_BUTTON_REPEAT_THRESHOLD;
 			inputRepeat[index] = 0;
 			inputRepeatPrev[index] = 0;
@@ -705,7 +718,9 @@ private:
 	static u32 myOutsGPFSEL1;
 	static bool InputButton[5];
 	static bool InputButtonPrev[5];
-	static u32 validInputCount[5];
+	// True while the button reads pressed, so UpdateButton can tell the first
+	// call of a press streak (when pressStartTime is stamped) from the rest.
+	static bool buttonPressed[5];
 	static u32 inputRepeatThreshold[5];
 	static u32 inputRepeat[5];
 	static u32 inputRepeatPrev[5];

--- a/src/emulation/iec_bus.h
+++ b/src/emulation/iec_bus.h
@@ -391,6 +391,18 @@ public:
 	}
 #endif
 
+	// Debounce/repeat timing here is measured in real elapsed microseconds
+	// (via ARM_SYSTIMER_CLO), not in call count. INPUT_BUTTON_DEBOUNCE_THRESHOLD
+	// and INPUT_BUTTON_REPEAT_THRESHOLD were written as raw counter increments
+	// on the assumption that this is called about once per microsecond - true
+	// for the CMD HD emulation loop (~1MHz), but the file browser's polling
+	// loop calls this at a much slower and less consistent rate (it also does
+	// directory scanning/screen drawing per iteration), so a normal press
+	// never accumulated anywhere near 20000 *calls* and buttons appeared
+	// completely unresponsive while browsing. Using elapsed time instead
+	// makes the debounce feel the same regardless of which loop is calling
+	// it. See AGENTS.md's "File Browser Button Unresponsive After Emulation"
+	// note for how this was diagnosed.
 	static void UpdateButton(int index, unsigned gplev0)
 	{
 		bool inputcurrent = (gplev0 & ButtonPinFlags[index]) == 0;
@@ -400,15 +412,20 @@ public:
 
 		if (inputcurrent)
 		{
+			if (validInputCount[index] == 0)
+				pressStartTime[index] = read32(ARM_SYSTIMER_CLO);	// start of this press streak
 			validInputCount[index]++;
-			if (validInputCount[index] == INPUT_BUTTON_DEBOUNCE_THRESHOLD)
+
+			u32 heldUs = read32(ARM_SYSTIMER_CLO) - pressStartTime[index];
+
+			if (!InputButton[index] && heldUs >= INPUT_BUTTON_DEBOUNCE_THRESHOLD)
 			{
 				InputButton[index] = true;
 				inputRepeatThreshold[index] = INPUT_BUTTON_DEBOUNCE_THRESHOLD + INPUT_BUTTON_REPEAT_THRESHOLD;
 				inputRepeat[index]++;
 			}
 
-			if (validInputCount[index] == inputRepeatThreshold[index])
+			if (InputButton[index] && heldUs >= inputRepeatThreshold[index])
 			{
 				inputRepeat[index]++;
 				inputRepeatThreshold[index] += INPUT_BUTTON_REPEAT_THRESHOLD / inputRepeat[index];
@@ -692,6 +709,7 @@ private:
 	static u32 inputRepeatThreshold[5];
 	static u32 inputRepeat[5];
 	static u32 inputRepeatPrev[5];
+	static u32 pressStartTime[5];
 
 };
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1110,8 +1110,13 @@ void emulator()
 				// was entered, and never update again - so after returning
 				// from CMD HD emulation (or any other exit path), the disk
 				// selection screen looks normal but nothing responds to
-				// button presses. See AGENTS.md's "File Browser Button
-				// Unresponsive After Emulation" note.
+				// button presses.
+				//
+				// Upstream Pi1541 got this for free: its browse loop called
+				// SimulateIECUpdate(), and iec_commands.cpp called
+				// ReadBrowseMode() from half a dozen places. Removing browse
+				// mode took the GPIO refresh with it, which is why the loss
+				// was not obvious in review.
 				IEC_Bus::ReadBrowseMode();
 
 				fileBrowser->Update();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1104,6 +1104,16 @@ void emulator()
 
 			while (emulating == IEC_COMMANDS)
 			{
+				// Refresh button/GPIO state every iteration. Without this the
+				// file browser's buttons only reflect whatever
+				// WaitForClearButtons() last polled right before this loop
+				// was entered, and never update again - so after returning
+				// from CMD HD emulation (or any other exit path), the disk
+				// selection screen looks normal but nothing responds to
+				// button presses. See AGENTS.md's "File Browser Button
+				// Unresponsive After Emulation" note.
+				IEC_Bus::ReadBrowseMode();
+
 				fileBrowser->Update();
 				if (fileBrowser->SelectionsMade())
 					emulating = BeginEmulating(fileBrowser, fileBrowser->LastSelectionName());


### PR DESCRIPTION
IEC_Bus::ReadBrowseMode() - which reads GPIO and updates the debounced button state - was never called inside the file browser's polling loop, only by WaitForClearButtons() right before entering it. So button state froze the instant browsing started and never updated again, leaving the disk selection screen fully unresponsive.

Also switches UpdateButton()'s debounce/repeat timing from a raw call counter to real elapsed microseconds (ARM_SYSTIMER_CLO). The counter approach assumed roughly one call per microsecond, true for the CMD HD emulation loop's ~1MHz cadence but not for the file browser's much slower and less consistent polling rate, so even after restoring the ReadBrowseMode() call a normal press never accumulated enough calls to cross the debounce threshold.