### PR TITLE
Do not lose acknowledged writes, and report it when we do

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,9 +380,17 @@ ROM is not there and is gitignored - it is not ours to redistribute - and
 - Supported Pi models: 3B/3B+ recommended (RASPPI=3 build). The 2MHz 65C02
   plus two VIAs is more work per microsecond than a 1MHz 1541; Pi Zero
   builds compile but are not expected to keep up.
-- DHD images are streamed from the SD card through a write-through cache
+- DHD images are streamed from the SD card through a RAM cache
   (`CMDHDCacheMB`). A cache miss stalls the emulated CPU for the duration
   of the SD access, exactly as if the SCSI drive were slow to respond.
+- That cache is **write behind**. A write is acknowledged to the computer as
+  soon as it reaches RAM and only reaches the card when the serial bus goes
+  quiet, when the drive is reset, or on eject - going to the card mid-command
+  freezes the emulated CPU far longer than the bus will wait. Cutting the
+  power, or pulling the card, with writes still in flight loses them. If a
+  flush does fail, the data stays cached for a retry and the drive reports
+  CHECK CONDITION / MEDIUM ERROR on its next command rather than pretending
+  the write landed.
 - Fast serial (C128 burst) is wired through U10's shift register at the bit
   level and SRQ is sampled/driven as the 1581 build did. C64 use (including
   JiffyDOS, which HDOS implements in software) is unaffected.

--- a/firmware/3b/options.txt
+++ b/firmware/3b/options.txt
@@ -47,6 +47,21 @@ CMDHDAtnOutGPIO = 24
 //CMDHDDeviceID = 0
 
 // Size in MB of the RAM cache in front of the DHD image.
+//
+// The cache is write behind, not write through: a write is acknowledged to the
+// computer as soon as it reaches RAM, and only reaches the card when the
+// serial bus goes quiet or the drive is reset. It has to work that way - going
+// to the card mid-command freezes the emulated CPU for tens of milliseconds
+// and the bus gives up long before that.
+//
+// So the cache is also a window in which acknowledged writes exist only in the
+// Pi's RAM. Pulling the power (or the card) inside that window loses them, and
+// the volume is then partly stale rather than obviously broken. Reset now
+// flushes, so reset-to-reboot is safe; yanking power is not.
+//
+// A smaller cache narrows the window and flushes more often, at the cost of
+// more trips to the card. Try 4 if you are doing a lot of writing - installing
+// GEOS or Wheels onto a partition, say - and want less in flight.
 //CMDHDCacheMB = 32
 
 // Front panel buttons. The real CMD HD has four: SWAP 8, SWAP 9,

--- a/src/emulation/picmdhd.cpp
+++ b/src/emulation/picmdhd.cpp
@@ -436,6 +436,17 @@ void PiCMDHD::Reset()
 	int units;
 	int i;
 
+	// Get acknowledged writes onto the card before the drive restarts.
+	//
+	// Writes are taken into the cache and acknowledged immediately - going to
+	// the card mid-command freezes the emulated CPU for as long as the card
+	// takes, which the bus will not tolerate. The flush therefore waits for an
+	// idle window. Reset is the one other safe moment: nothing is mid-transfer
+	// and a pause here costs nothing, whereas resetting or powering off with
+	// dirty chunks still in RAM loses writes the computer was told had landed.
+	// That is what turns "copy the files, reset, boot" into a corrupt volume.
+	ScsiImage::FlushAll();
+
 	via9.Reset();
 	via10.Reset();
 

--- a/src/emulation/scsi.cpp
+++ b/src/emulation/scsi.cpp
@@ -130,23 +130,40 @@ void ScsiImage::Detach()
 	}
 }
 
-void ScsiImage::Sync(bool force)
+int ScsiImage::Sync(bool force)
 {
 	if (!attached || !needSync)
-		return;
+		return 0;
 
 	// Only ever flush on demand. This used to run on a timer from the SCSI
 	// state machine returning to BUSFREE - which is between commands, exactly
 	// when the computer is about to poll for status. A single SD access has
 	// been measured at 35ms on this hardware, far longer than the bus will
 	// wait, so the drive vanished mid-transfer. Flushing now happens only when
-	// the bus has gone quiet (FlushIdle) or on detach.
+	// the bus has gone quiet (FlushAll from the idle check), on reset, or on
+	// detach.
 	if (!force)
-		return;
+		return 0;
 
-	FlushAllDirty();
-	f_sync(&file);
+	int failed = FlushAllDirty();
+
+	// f_sync pushes FatFS's own metadata (the directory entry and FAT chain).
+	// Losing that loses the file, not just the sectors, so it counts too.
+	if (f_sync(&file) != FR_OK)
+		++failed;
+
+	if (failed)
+	{
+		// Leave needSync set: the dirty chunks are still dirty and the next
+		// flush must try them again.
+		writeErrorPending = true;
+		++writeErrors;
+		DEBUG_LOG("SCSI: %d chunk(s) failed to write on '%s' - data kept for retry\r\n", failed, name);
+		return -1;
+	}
+
 	needSync = false;
+	return 0;
 }
 
 ScsiImage::CacheSlot* ScsiImage::FindSlot(u32 chunkIndex, bool allocate)
@@ -193,19 +210,23 @@ ScsiImage* ScsiImage::attachedImages[64] = { 0 };
 u32 ScsiImage::numAttachedImages = 0;
 u32 ScsiImage::worstStallMicros = 0;
 u32 ScsiImage::accessCounter = 0;
+u32 ScsiImage::writeErrors = 0;
 
-void ScsiImage::FlushIdle()
+int ScsiImage::FlushAll()
 {
+	int failed = 0;
+
 	for (u32 i = 0; i < numAttachedImages; ++i)
 	{
 		ScsiImage* img = attachedImages[i];
 		if (img && img->attached && img->needSync)
 		{
-			img->FlushAllDirty();
-			f_sync(&img->file);
-			img->needSync = false;
+			if (img->Sync(true) != 0)
+				++failed;
 		}
 	}
+
+	return failed;
 }
 
 ScsiImage* ScsiImage::ImageById(u8 id)
@@ -350,6 +371,13 @@ int ScsiImage::WriteSector(u32 lba, const u8* buffer)
 	if (!attached || readOnly)
 		return -1;
 
+	// A deferred flush failed since the last command. The host was told that
+	// write succeeded and cannot be told otherwise now, so report the error
+	// here instead - once - and let HDOS surface it. The data itself is still
+	// dirty in the cache and will be retried.
+	if (TakeWriteError())
+		return -1;
+
 	if (lba >= sizeInSectors)
 		return -1;
 
@@ -408,23 +436,38 @@ int ScsiImage::FlushChunk(CacheSlot& slot)
 		u64 offset = ((u64)slot.chunkIndex << CACHE_CHUNK_SHIFT) + (u64)s * SECTOR_SIZE;
 		if (f_lseek(&file, offset) != FR_OK)
 			return -1;
-		if (f_write(&file, slot.data + s * SECTOR_SIZE, run * SECTOR_SIZE, &written) != FR_OK)
+		// A short write counts as a failure. FatFS reports one on a full card
+		// without setting an error, and taking it for success is how a full
+		// card used to turn into silent corruption: the run below would clear
+		// the dirty bits and the only copy of the data went away.
+		if (f_write(&file, slot.data + s * SECTOR_SIZE, run * SECTOR_SIZE, &written) != FR_OK ||
+			written != run * SECTOR_SIZE)
 			return -1;
 		NoteStall(t0);
+
+		// Clear only what actually reached the card, so a failure part way
+		// through a chunk leaves the rest dirty for the next attempt.
+		slot.dirtyMask &= (u8)~(((1 << run) - 1) << s);
 		s += run;
 	}
 
-	slot.dirtyMask = 0;
 	return 0;
 }
 
-void ScsiImage::FlushAllDirty()
+int ScsiImage::FlushAllDirty()
 {
+	int failed = 0;
+
 	for (u32 i = 0; i < numCacheSlots; ++i)
 	{
 		if (cacheSlots[i].valid && cacheSlots[i].dirtyMask && cacheSlots[i].image == imageId)
-			FlushChunk(cacheSlots[i]);
+		{
+			if (FlushChunk(cacheSlots[i]) != 0)
+				++failed;
+		}
 	}
+
+	return failed;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -734,6 +777,10 @@ void scsi_process_ack(scsi_context_t* context)
 				{
 					if (scsi_image_write(context))
 					{
+						// Say why, so REQUEST SENSE returns something
+						// meaningful instead of whatever was left over from
+						// the last command.
+						context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
 						context->status = SCSI_STATUS_CHECKCONDITION;
 						context->state = SCSI_STATE_STATUS;
 						break;

--- a/src/emulation/scsi.h
+++ b/src/emulation/scsi.h
@@ -44,7 +44,7 @@ public:
 	static const u32 CACHE_CHUNK_SIZE = 1 << CACHE_CHUNK_SHIFT;
 	static const u32 SECTORS_PER_CHUNK = CACHE_CHUNK_SIZE / SECTOR_SIZE;
 
-	ScsiImage() : attached(false), sizeInSectors(0), readOnly(false) {}
+	ScsiImage() : attached(false), sizeInSectors(0), readOnly(false), needSync(false), writeErrorPending(false) {}
 
 	bool Attach(const char* filename, bool readOnly);
 	void Detach();
@@ -71,15 +71,30 @@ public:
 	// left alone.
 	static u32 AccessCounter() { return accessCounter; }
 
-	// Flush every attached image. Only call this when the serial bus is quiet:
-	// it goes to the card, which freezes the emulated CPU, and a frozen CPU
-	// cannot answer ATN.
-	static void FlushIdle();
+	// Flush every attached image. Returns the number of images that could not
+	// be written. Only call this when the serial bus is quiet: it goes to the
+	// card, which freezes the emulated CPU, and a frozen CPU cannot answer
+	// ATN. Reset is also a safe moment - the drive is restarting anyway, and
+	// losing acknowledged writes there is worse than a pause.
+	static int FlushAll();
 
 	// Flush dirty chunks and FatFS metadata. Does nothing unless forced -
 	// going to the card at an arbitrary moment is what broke the bus. Detach
-	// forces it; everything else waits for FlushIdle.
-	void Sync(bool force = false);
+	// and reset force it; everything else waits for an idle window.
+	// Returns 0 on success.
+	int Sync(bool force = false);
+
+	// Writes are acknowledged to the host as soon as they reach the cache, so
+	// by the time a flush fails the computer has long since been told the
+	// write succeeded. There is no way to un-acknowledge it, so instead the
+	// data stays dirty for a later retry and this latches - the next command
+	// for the image reports CHECK CONDITION / MEDIUM ERROR so the failure
+	// surfaces as a drive error rather than as silent corruption.
+	bool HasWriteError() const { return writeErrorPending; }
+	bool TakeWriteError() { bool e = writeErrorPending; writeErrorPending = false; return e; }
+
+	// Total flush failures since boot, for the display and for bug reports.
+	static u32 WriteErrorCount() { return writeErrors; }
 
 	// The (global) cache used by all images.
 	static void InitCache(u32 sizeInBytes);
@@ -90,8 +105,10 @@ private:
 	u32 sizeInSectors;
 	bool readOnly;
 	bool needSync;
+	bool writeErrorPending;
 	static u32 worstStallMicros;
 	static u32 accessCounter;
+	static u32 writeErrors;
 
 	char name[256];
 
@@ -112,8 +129,10 @@ private:
 
 	// Push one dirty chunk out to the card. Used when a slot is reused for
 	// something else, and by Sync.
+	// Both return 0 on success. A chunk that fails keeps its dirty bits so the
+	// next flush tries again rather than dropping the data on the floor.
 	int FlushChunk(CacheSlot& slot);
-	void FlushAllDirty();
+	int FlushAllDirty();
 	static void NoteStall(u32 startMicros);
 
 	// A chunk being evicted can belong to a different disk, so we need to get
@@ -147,6 +166,7 @@ private:
 #define SCSI_STATUS_CHECKCONDITION           0x01
 
 #define SCSI_SENSEKEY_NOSENSE        0x00
+#define SCSI_SENSEKEY_MEDIUMERROR    0x03
 #define SCSI_SENSEKEY_ILLEGALREQUEST 0x05
 
 #define SCSI_SASC_LOGICALBLOCKADDRESSOUTOFRANGE 0x21

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -947,7 +947,7 @@ EXIT_TYPE EmulateCMDHD(FileBrowser* fileBrowser)
 			else if (++quietLoops >= 500000)		// this loop runs at 1MHz
 			{
 				quietLoops = 0;
-				ScsiImage::FlushIdle();
+				ScsiImage::FlushAll();		// idle window - safe to touch the card
 			}
 		}
 


### PR DESCRIPTION
Three related holes in the DHD write path. Individually each is small; together they turn an ordinary "copy files onto a partition, reset, boot it" cycle into a partly stale volume, with nothing reported anywhere.

Found while investigating frequent corruption of a 1581 partition that Wheels had just been installed onto — booting it yielded a different failure each time.

### 1. Reset did not flush

Writes are taken into the cache and acknowledged immediately. That is deliberate and correct: going to the card mid-command freezes the emulated CPU for tens of milliseconds and the bus gives up long before that, which is exactly the bug the comment in `Sync` describes. So the flush waits for the serial bus to go quiet.

But `PiCMDHD::Reset()` never flushed. So resetting the drive to try a freshly written boot volume could discard the very writes being tested. Worse, the idle check in `main.cpp` resets its counter whenever there is SCSI activity **or `IEC_Bus::IsAtnAsserted()`**, so a busy bus can push the flush window out indefinitely — "wait a moment before resetting" is not a reliable workaround.

Reset is a safe moment to touch the card: nothing is mid-transfer and the drive is restarting anyway.

### 2. A short write counted as success

`FlushChunk` checked `f_write`'s return value but ignored the byte count — unlike `WriteSector`, which checks both:

```c
// WriteSector, correct:
if (f_write(..., &bytesWritten) != FR_OK || bytesWritten != SECTOR_SIZE)

// FlushChunk, before:
if (f_write(..., &written) != FR_OK)     // `written` never read
```

FatFS reports a short write on a full card *without* setting an error. So the run was taken as written, `dirtyMask` was cleared at the end of the chunk, and the only copy of the data went away.

It now also clears only the bits that actually reached the card, so a failure part way through a chunk leaves the rest dirty to retry rather than discarding the lot.

### 3. Failures were swallowed

`FlushAllDirty()` returned `void`, discarding every `FlushChunk` result, and both `Sync` and `FlushIdle` set `needSync = false` unconditionally — so an error vanished and the cache was marked clean regardless. `f_sync`'s return was ignored too, which matters because that is FatFS's own metadata: losing it loses the file, not just some sectors.

They now return a status and keep the data dirty for a later attempt. Since the host was told the write succeeded long ago and cannot be told otherwise, the failure is latched and the **next** command for that image reports `CHECK CONDITION` with `MEDIUM ERROR`. The sense key is now set explicitly at that call site rather than leaving whatever the previous command happened to put there.

Net effect: a failing or full card surfaces as a drive error instead of as silent corruption.

`FlushIdle` is renamed `FlushAll`, since reset is now a second caller and the old name described *when* it was called rather than what it does.

### Docs

The README called the cache "write-through", which it is not. Both that and `options.txt` now describe the actual behaviour, including that a smaller `CMDHDCacheMB` narrows the window if you are doing a lot of writing.

### Testing

Builds clean for `RASPPI=3` (arm-none-eabi-gcc 13.3.1). **Not yet tested on hardware** — the interesting cases are a genuinely full or failing card, which I have not reproduced. The reset-flush path is straightforward to exercise; the error path needs a card that actually fails.

Worth a look from someone who can force a write failure. In particular, returning an error on the *next* command is a deliberate trade — it surfaces the problem at the cost of failing a command that would otherwise have succeeded. I think that is the right call for a hard drive emulator, but it is a judgement call.

---

*Disclosure: this change was written with Claude (Anthropic's Claude Code); the commit carries a `Co-Authored-By` trailer. The diagnosis came out of a real corruption problem, but the failure paths themselves have not been exercised on hardware.*
