### PR TITLE
Stop the cache losing data on eviction, detach and reset

### DIFF
--- a/src/emulation/picmdhd.cpp
+++ b/src/emulation/picmdhd.cpp
@@ -449,10 +449,9 @@ void PiCMDHD::Reset()
 	// A full flush is unbounded - 32MB of cache is 8192 chunks, and at the 35ms
 	// per access measured on this hardware that is minutes. So take a slice and
 	// leave the rest to the idle path, which runs when the bus is genuinely
-	// quiet. RESET_FLUSH_CHUNKS is about a quarter second of card time at the
-	// worst measured rate, which the host will not notice on top of its own
-	// reset.
-	ScsiImage::FlushSome(ScsiImage::RESET_FLUSH_CHUNKS);
+	// quiet. The slice is a quarter second of real time, which the host will
+	// not notice on top of its own reset.
+	ScsiImage::FlushSome(ScsiImage::RESET_FLUSH_MICROS);
 
 	via9.Reset();
 	via10.Reset();

--- a/src/emulation/picmdhd.cpp
+++ b/src/emulation/picmdhd.cpp
@@ -436,16 +436,23 @@ void PiCMDHD::Reset()
 	int units;
 	int i;
 
-	// Get acknowledged writes onto the card before the drive restarts.
+	// Write back a bounded amount before the drive restarts.
 	//
-	// Writes are taken into the cache and acknowledged immediately - going to
-	// the card mid-command freezes the emulated CPU for as long as the card
-	// takes, which the bus will not tolerate. The flush therefore waits for an
-	// idle window. Reset is the one other safe moment: nothing is mid-transfer
-	// and a pause here costs nothing, whereas resetting or powering off with
-	// dirty chunks still in RAM loses writes the computer was told had landed.
-	// That is what turns "copy the files, reset, boot" into a corrupt volume.
-	ScsiImage::FlushAll();
+	// Reset is a good moment to get dirty chunks onto the card - the machine
+	// is usually about to be powered off or reconfigured, and the cache is the
+	// only copy of anything acknowledged but not yet written. It is not a free
+	// moment though: this path is reached from the IEC RESET line as well as
+	// from the front panel button, and WaitUntilReset() returns as soon as the
+	// host releases RESET. The computer is therefore already running and about
+	// to poll a drive that cannot answer ATN while it is talking to the card.
+	//
+	// A full flush is unbounded - 32MB of cache is 8192 chunks, and at the 35ms
+	// per access measured on this hardware that is minutes. So take a slice and
+	// leave the rest to the idle path, which runs when the bus is genuinely
+	// quiet. RESET_FLUSH_CHUNKS is about a quarter second of card time at the
+	// worst measured rate, which the host will not notice on top of its own
+	// reset.
+	ScsiImage::FlushSome(ScsiImage::RESET_FLUSH_CHUNKS);
 
 	via9.Reset();
 	via10.Reset();

--- a/src/emulation/scsi.cpp
+++ b/src/emulation/scsi.cpp
@@ -35,7 +35,7 @@
 u8* ScsiImage::cachePool = 0;
 ScsiImage::CacheSlot* ScsiImage::cacheSlots = 0;
 u32 ScsiImage::numCacheSlots = 0;
-u8 ScsiImage::nextImageId = 0;
+u32 ScsiImage::nextImageId = 0;
 
 void ScsiImage::InitCache(u32 sizeInBytes)
 {
@@ -111,13 +111,18 @@ void ScsiImage::Detach()
 		// card problem. After that the file has to be closed regardless - there
 		// is nowhere else for the data to go - so all that is left is to say so
 		// loudly rather than invalidate the slots as if nothing happened.
-		if (Sync(true) != 0 && Sync(true) != 0)
-		{
-			DEBUG_LOG("SCSI: '%s' detached with %d unwritten chunk(s) - DATA LOST\r\n",
-				name, FlushAllDirty());
-		}
+		//
+		// The report only counts; it must not flush again, or the diagnostic
+		// becomes a third write attempt and can report zero after succeeding.
+		if (Sync(true) < 0 && Sync(true) < 0)
+			DEBUG_LOG("SCSI: '%s' detached with unwritten data - DATA LOST\r\n", name);
+		else if (HasDirtyChunks())
+			DEBUG_LOG("SCSI: '%s' detached with chunks still dirty - DATA LOST\r\n", name);
 
-		f_close(&file);
+		// f_close writes the directory entry, so it is the last chance for
+		// anything to go wrong and worth reporting too.
+		if (f_close(&file) != FR_OK)
+			DEBUG_LOG("SCSI: closing '%s' failed - the file may be truncated\r\n", name);
 		attached = false;
 
 		for (u32 i = 0; i < numAttachedImages; ++i)
@@ -139,7 +144,7 @@ void ScsiImage::Detach()
 	}
 }
 
-int ScsiImage::Sync(bool force, u32 maxChunks, u32* sharedFlushed)
+int ScsiImage::Sync(bool force, u32 deadline)
 {
 	if (!attached || !needSync)
 		return 0;
@@ -154,10 +159,13 @@ int ScsiImage::Sync(bool force, u32 maxChunks, u32* sharedFlushed)
 	if (!force)
 		return 0;
 
-	u32 localFlushed = 0;
-	u32* flushed = sharedFlushed ? sharedFlushed : &localFlushed;
-	int failed = FlushAllDirty(maxChunks, flushed);
-	bool partial = maxChunks && *flushed >= maxChunks;
+	int failed = FlushAllDirty(deadline);
+
+	// Partial means "there is still dirty data", not "the budget was reached".
+	// Those differ when the budget lands exactly on the last chunk, and
+	// treating that as partial would skip f_sync and leave needSync set on a
+	// cache that is in fact clean.
+	bool partial = HasDirtyChunks();
 
 	// f_sync pushes FatFS's own metadata (the directory entry and FAT chain).
 	// Losing that loses the file, not just the sectors, so it counts too. Skip
@@ -192,7 +200,7 @@ bool ScsiImage::EvictSlot(CacheSlot* victim)
 		// The image was detached without this chunk being written. Nothing can
 		// write it now - the FIL is closed - so it is already lost; say so
 		// rather than quietly reusing the slot.
-		DEBUG_LOG("SCSI: dirty chunk for detached image %d dropped\r\n", victim->image);
+		DEBUG_LOG("SCSI: dirty chunk for detached image %u dropped\r\n", victim->image);
 		++writeErrors;
 		victim->dirtyMask = 0;
 		return true;
@@ -227,8 +235,16 @@ ScsiImage::CacheSlot* ScsiImage::FindSlot(u32 chunkIndex, bool allocate)
 	if (!allocate)
 		return 0;
 
-	// Prefer replacing an invalid slot.
-	CacheSlot* victim = slot->valid ? (slot2->valid ? slot : slot2) : slot;
+	// Invalid first, then clean, then dirty. Evicting a dirty slot means going
+	// to the card from inside a SCSI command - the thing this whole design
+	// exists to avoid - so a clean slot is worth taking even when the other
+	// way would be the more natural victim.
+	CacheSlot* victim;
+	if (!slot->valid)			victim = slot;
+	else if (!slot2->valid)		victim = slot2;
+	else if (!slot->dirtyMask)	victim = slot;
+	else if (!slot2->dirtyMask)	victim = slot2;
+	else						victim = slot;		// both dirty; one has to go
 
 	// Never drop writes on the floor. The chunk being evicted may belong to
 	// another image, so flush it through whoever owns it.
@@ -260,23 +276,23 @@ u32 ScsiImage::worstStallMicros = 0;
 u32 ScsiImage::accessCounter = 0;
 u32 ScsiImage::writeErrors = 0;
 
-int ScsiImage::FlushSome(u32 maxChunks)
+int ScsiImage::FlushSome(u32 maxMicros)
 {
 	int failed = 0;
 
-	// One budget shared across every image, not one each, so the worst case
-	// stays bounded no matter how many are mounted.
-	u32 flushed = 0;
+	// One deadline for the whole call, so the bound holds however many images
+	// are mounted rather than being per image.
+	u32 deadline = maxMicros ? (read32(ARM_SYSTIMER_CLO) + maxMicros) : 0;
 
 	for (u32 i = 0; i < numAttachedImages; ++i)
 	{
-		if (maxChunks && flushed >= maxChunks)
+		if (deadline && (s32)(read32(ARM_SYSTIMER_CLO) - deadline) >= 0)
 			break;
 
 		ScsiImage* img = attachedImages[i];
 		if (img && img->attached && img->needSync)
 		{
-			if (img->Sync(true, maxChunks, &flushed) < 0)
+			if (img->Sync(true, deadline) < 0)
 				++failed;
 		}
 	}
@@ -289,7 +305,7 @@ int ScsiImage::FlushAll()
 	return FlushSome(0);
 }
 
-ScsiImage* ScsiImage::ImageById(u8 id)
+ScsiImage* ScsiImage::ImageById(u32 id)
 {
 	for (u32 i = 0; i < numAttachedImages; ++i)
 	{
@@ -520,25 +536,40 @@ int ScsiImage::FlushChunk(CacheSlot& slot)
 	return 0;
 }
 
-int ScsiImage::FlushAllDirty(u32 maxChunks, u32* flushed)
+int ScsiImage::FlushAllDirty(u32 deadline)
 {
 	int failed = 0;
 
 	for (u32 i = 0; i < numCacheSlots; ++i)
 	{
-		if (maxChunks && flushed && *flushed >= maxChunks)
+		// Budget in real time, not in chunks. A chunk is up to four separate
+		// writes when its dirty sectors are not contiguous, so counting chunks
+		// bounds the work by a factor of four at best. An absolute deadline
+		// also shares itself across images for free.
+		//
+		// Signed difference so it stays correct across the timer's ~71.6
+		// minute wrap.
+		if (deadline && (s32)(read32(ARM_SYSTIMER_CLO) - deadline) >= 0)
 			break;
 
 		if (cacheSlots[i].valid && cacheSlots[i].dirtyMask && cacheSlots[i].image == imageId)
 		{
 			if (FlushChunk(cacheSlots[i]) != 0)
 				++failed;
-			if (flushed)
-				++(*flushed);
 		}
 	}
 
 	return failed;
+}
+
+bool ScsiImage::HasDirtyChunks() const
+{
+	for (u32 i = 0; i < numCacheSlots; ++i)
+	{
+		if (cacheSlots[i].valid && cacheSlots[i].dirtyMask && cacheSlots[i].image == imageId)
+			return true;
+	}
+	return false;
 }
 
 

--- a/src/emulation/scsi.cpp
+++ b/src/emulation/scsi.cpp
@@ -499,7 +499,13 @@ int ScsiImage::WriteSector(u32 lba, const u8* buffer)
 
 // Push a chunk's dirty sectors out to the card, in as few writes as the
 // runs of set bits allow.
-int ScsiImage::FlushChunk(CacheSlot& slot)
+//
+// deadline (0 for none) is checked between runs, so a budgeted flush can stop
+// part way through a chunk. That is safe because only the bits that actually
+// reached the card are cleared - what is left simply stays dirty. Eviction
+// passes no deadline: it needs the whole chunk out before it can reuse the
+// slot.
+int ScsiImage::FlushChunk(CacheSlot& slot, u32 deadline)
 {
 	if (!slot.valid || !slot.dirtyMask)
 		return 0;
@@ -508,6 +514,9 @@ int ScsiImage::FlushChunk(CacheSlot& slot)
 	while (s < SECTORS_PER_CHUNK)
 	{
 		if (!(slot.dirtyMask & (1 << s))) { ++s; continue; }
+
+		if (deadline && (s32)(read32(ARM_SYSTIMER_CLO) - deadline) >= 0)
+			return 0;
 
 		u32 run = 1;
 		while (s + run < SECTORS_PER_CHUNK && (slot.dirtyMask & (1 << (s + run))))
@@ -554,7 +563,7 @@ int ScsiImage::FlushAllDirty(u32 deadline)
 
 		if (cacheSlots[i].valid && cacheSlots[i].dirtyMask && cacheSlots[i].image == imageId)
 		{
-			if (FlushChunk(cacheSlots[i]) != 0)
+			if (FlushChunk(cacheSlots[i], deadline) != 0)
 				++failed;
 		}
 	}

--- a/src/emulation/scsi.cpp
+++ b/src/emulation/scsi.cpp
@@ -107,7 +107,16 @@ void ScsiImage::Detach()
 {
 	if (attached)
 	{
-		Sync(true);
+		// One retry, because the usual cause of a first failure is a transient
+		// card problem. After that the file has to be closed regardless - there
+		// is nowhere else for the data to go - so all that is left is to say so
+		// loudly rather than invalidate the slots as if nothing happened.
+		if (Sync(true) != 0 && Sync(true) != 0)
+		{
+			DEBUG_LOG("SCSI: '%s' detached with %d unwritten chunk(s) - DATA LOST\r\n",
+				name, FlushAllDirty());
+		}
+
 		f_close(&file);
 		attached = false;
 
@@ -130,7 +139,7 @@ void ScsiImage::Detach()
 	}
 }
 
-int ScsiImage::Sync(bool force)
+int ScsiImage::Sync(bool force, u32 maxChunks, u32* sharedFlushed)
 {
 	if (!attached || !needSync)
 		return 0;
@@ -145,11 +154,16 @@ int ScsiImage::Sync(bool force)
 	if (!force)
 		return 0;
 
-	int failed = FlushAllDirty();
+	u32 localFlushed = 0;
+	u32* flushed = sharedFlushed ? sharedFlushed : &localFlushed;
+	int failed = FlushAllDirty(maxChunks, flushed);
+	bool partial = maxChunks && *flushed >= maxChunks;
 
 	// f_sync pushes FatFS's own metadata (the directory entry and FAT chain).
-	// Losing that loses the file, not just the sectors, so it counts too.
-	if (f_sync(&file) != FR_OK)
+	// Losing that loses the file, not just the sectors, so it counts too. Skip
+	// it on a partial pass: there is more to write, and this is the expensive
+	// part of a budgeted flush.
+	if (!partial && f_sync(&file) != FR_OK)
 		++failed;
 
 	if (failed)
@@ -162,8 +176,36 @@ int ScsiImage::Sync(bool force)
 		return -1;
 	}
 
-	needSync = false;
-	return 0;
+	// Only clean if everything actually went out.
+	if (!partial)
+		needSync = false;
+	return partial ? 1 : 0;
+}
+
+// Write a slot's dirty sectors back so it can be reused. Returns false if the
+// data could not be written and the slot must therefore be left alone.
+bool ScsiImage::EvictSlot(CacheSlot* victim)
+{
+	ScsiImage* owner = ImageById(victim->image);
+	if (!owner)
+	{
+		// The image was detached without this chunk being written. Nothing can
+		// write it now - the FIL is closed - so it is already lost; say so
+		// rather than quietly reusing the slot.
+		DEBUG_LOG("SCSI: dirty chunk for detached image %d dropped\r\n", victim->image);
+		++writeErrors;
+		victim->dirtyMask = 0;
+		return true;
+	}
+
+	if (owner->FlushChunk(*victim) != 0)
+	{
+		owner->writeErrorPending = true;
+		++writeErrors;
+		return false;
+	}
+
+	return true;
 }
 
 ScsiImage::CacheSlot* ScsiImage::FindSlot(u32 chunkIndex, bool allocate)
@@ -190,12 +232,18 @@ ScsiImage::CacheSlot* ScsiImage::FindSlot(u32 chunkIndex, bool allocate)
 
 	// Never drop writes on the floor. The chunk being evicted may belong to
 	// another image, so flush it through whoever owns it.
-	if (victim->valid && victim->dirtyMask)
+	//
+	// If it cannot be written - card full, card gone, or the owning image has
+	// been detached - the data must not be evicted, because the cache is the
+	// only copy. Try the other way of the set, and if that is unwritable too,
+	// refuse to allocate. WriteSector then falls back to writing straight
+	// through, which is slow but reports its own failure honestly.
+	if (victim->valid && victim->dirtyMask && !EvictSlot(victim))
 	{
-		ScsiImage* owner = ImageById(victim->image);
-		if (owner)
-			owner->FlushChunk(*victim);
-		victim->dirtyMask = 0;
+		CacheSlot* other = (victim == slot) ? slot2 : slot;
+		if (other == victim || (other->valid && other->dirtyMask && !EvictSlot(other)))
+			return 0;
+		victim = other;
 	}
 
 	victim->valid = 0;
@@ -212,21 +260,33 @@ u32 ScsiImage::worstStallMicros = 0;
 u32 ScsiImage::accessCounter = 0;
 u32 ScsiImage::writeErrors = 0;
 
-int ScsiImage::FlushAll()
+int ScsiImage::FlushSome(u32 maxChunks)
 {
 	int failed = 0;
 
+	// One budget shared across every image, not one each, so the worst case
+	// stays bounded no matter how many are mounted.
+	u32 flushed = 0;
+
 	for (u32 i = 0; i < numAttachedImages; ++i)
 	{
+		if (maxChunks && flushed >= maxChunks)
+			break;
+
 		ScsiImage* img = attachedImages[i];
 		if (img && img->attached && img->needSync)
 		{
-			if (img->Sync(true) != 0)
+			if (img->Sync(true, maxChunks, &flushed) < 0)
 				++failed;
 		}
 	}
 
 	return failed;
+}
+
+int ScsiImage::FlushAll()
+{
+	return FlushSome(0);
 }
 
 ScsiImage* ScsiImage::ImageById(u8 id)
@@ -350,10 +410,16 @@ int ScsiImage::ReadSectorUncached(u32 lba, u8* buffer)
 
 	// If the sector happens to be cached, take it from there - but never fill
 	// the cache on its account.
+	//
+	// validMask has to be checked, not just valid: a slot created by writing
+	// one sector holds nothing but uninitialised RAM for the other seven, and
+	// handing that back as disk contents is how the base LBA scan ends up
+	// finding a CMD signature that was never on the card.
+	u32 sectorInChunk = lba % SECTORS_PER_CHUNK;
 	CacheSlot* slot = FindSlot(lba / SECTORS_PER_CHUNK, false);
-	if (slot && slot->valid)
+	if (slot && slot->valid && (slot->validMask & (1 << sectorInChunk)))
 	{
-		memcpy(buffer, slot->data + (lba % SECTORS_PER_CHUNK) * SECTOR_SIZE, SECTOR_SIZE);
+		memcpy(buffer, slot->data + sectorInChunk * SECTOR_SIZE, SECTOR_SIZE);
 		return 0;
 	}
 
@@ -454,21 +520,27 @@ int ScsiImage::FlushChunk(CacheSlot& slot)
 	return 0;
 }
 
-int ScsiImage::FlushAllDirty()
+int ScsiImage::FlushAllDirty(u32 maxChunks, u32* flushed)
 {
 	int failed = 0;
 
 	for (u32 i = 0; i < numCacheSlots; ++i)
 	{
+		if (maxChunks && flushed && *flushed >= maxChunks)
+			break;
+
 		if (cacheSlots[i].valid && cacheSlots[i].dirtyMask && cacheSlots[i].image == imageId)
 		{
 			if (FlushChunk(cacheSlots[i]) != 0)
 				++failed;
+			if (flushed)
+				++(*flushed);
 		}
 	}
 
 	return failed;
 }
+
 
 ///////////////////////////////////////////////////////////////////////////////
 // SCSI target state machine (from VICE scsi.c).

--- a/src/emulation/scsi.h
+++ b/src/emulation/scsi.h
@@ -78,22 +78,29 @@ public:
 	// losing acknowledged writes there is worse than a pause.
 	static int FlushAll();
 
-	// As FlushAll, but stops after roughly maxChunks chunks (0 = no limit).
+	// As FlushAll, but gives up after maxMicros of real time (0 = no limit).
 	// Reset uses this: that path is reached from the IEC RESET line with the
 	// host already running, so an unbounded flush would take the drive off the
 	// bus for as long as the card needs - minutes, with a large dirty cache.
-	static int FlushSome(u32 maxChunks);
+	//
+	// The budget is time rather than chunks because a chunk is up to four
+	// separate writes when its dirty sectors are not contiguous, so a chunk
+	// count bounds the work only to within a factor of four.
+	static int FlushSome(u32 maxMicros);
 
-	// About a quarter second of card time at the worst measured rate.
-	static const u32 RESET_FLUSH_CHUNKS = 8;
+	// Quarter of a second: unnoticeable on top of the host's own reset, and
+	// enough for several chunks even at the worst measured card latency.
+	static const u32 RESET_FLUSH_MICROS = 250000;
 
 	// Flush dirty chunks and FatFS metadata. Does nothing unless forced -
 	// going to the card at an arbitrary moment is what broke the bus. Detach
 	// and reset force it; everything else waits for an idle window.
-	// Returns 0 if everything went out, 1 if the chunk budget stopped it part
-	// way (more still dirty), negative on a write failure. sharedFlushed lets
-	// several images draw on one budget; pass 0 for a private one.
-	int Sync(bool force = false, u32 maxChunks = 0, u32* sharedFlushed = 0);
+	//
+	// deadline is an absolute ARM_SYSTIMER_CLO value, 0 for no limit; one
+	// deadline shared by several images bounds the whole flush rather than
+	// each image separately. Returns 0 if everything went out, 1 if dirty
+	// chunks remain, negative on a write failure.
+	int Sync(bool force = false, u32 deadline = 0);
 
 	// Writes are acknowledged to the host as soon as they reach the cache, so
 	// by the time a flush fails the computer has long since been told the
@@ -127,7 +134,7 @@ private:
 	{
 		u8* data;
 		u32 chunkIndex;
-		u8 image;		// which image (index into a small registry)
+		u32 image;		// which image owns this chunk; see nextImageId
 		u8 valid;		// slot is allocated to this chunk
 		// Per sector, because a write must never have to read first. Reading
 		// the chunk in just to modify one sector of it meant an SD access on
@@ -143,7 +150,12 @@ private:
 	// Both return 0 on success. A chunk that fails keeps its dirty bits so the
 	// next flush tries again rather than dropping the data on the floor.
 	int FlushChunk(CacheSlot& slot);
-	int FlushAllDirty(u32 maxChunks = 0, u32* flushed = 0);
+	int FlushAllDirty(u32 deadline = 0);
+
+	// Whether this image still has chunks waiting to be written. Read only -
+	// callers use it to decide whether a flush finished, so it must not be
+	// tempted into writing anything itself.
+	bool HasDirtyChunks() const;
 
 	// Write a slot back so it can be reused. False means the data could not be
 	// written and the slot must be left where it is - the cache is the only
@@ -155,14 +167,14 @@ private:
 	// back from the id stored in the slot to the image that owns the file.
 	static ScsiImage* attachedImages[64];
 	static u32 numAttachedImages;
-	static ScsiImage* ImageById(u8 id);
+	static ScsiImage* ImageById(u32 id);
 
 	static u8* cachePool;
 	static CacheSlot* cacheSlots;
 	static u32 numCacheSlots;
-	static u8 nextImageId;
+	static u32 nextImageId;
 
-	u8 imageId;
+	u32 imageId;
 
 	int FillChunk(u32 chunkIndex, CacheSlot& slot);
 	CacheSlot* FindSlot(u32 chunkIndex, bool allocate);

--- a/src/emulation/scsi.h
+++ b/src/emulation/scsi.h
@@ -78,11 +78,22 @@ public:
 	// losing acknowledged writes there is worse than a pause.
 	static int FlushAll();
 
+	// As FlushAll, but stops after roughly maxChunks chunks (0 = no limit).
+	// Reset uses this: that path is reached from the IEC RESET line with the
+	// host already running, so an unbounded flush would take the drive off the
+	// bus for as long as the card needs - minutes, with a large dirty cache.
+	static int FlushSome(u32 maxChunks);
+
+	// About a quarter second of card time at the worst measured rate.
+	static const u32 RESET_FLUSH_CHUNKS = 8;
+
 	// Flush dirty chunks and FatFS metadata. Does nothing unless forced -
 	// going to the card at an arbitrary moment is what broke the bus. Detach
 	// and reset force it; everything else waits for an idle window.
-	// Returns 0 on success.
-	int Sync(bool force = false);
+	// Returns 0 if everything went out, 1 if the chunk budget stopped it part
+	// way (more still dirty), negative on a write failure. sharedFlushed lets
+	// several images draw on one budget; pass 0 for a private one.
+	int Sync(bool force = false, u32 maxChunks = 0, u32* sharedFlushed = 0);
 
 	// Writes are acknowledged to the host as soon as they reach the cache, so
 	// by the time a flush fails the computer has long since been told the
@@ -132,7 +143,12 @@ private:
 	// Both return 0 on success. A chunk that fails keeps its dirty bits so the
 	// next flush tries again rather than dropping the data on the floor.
 	int FlushChunk(CacheSlot& slot);
-	int FlushAllDirty();
+	int FlushAllDirty(u32 maxChunks = 0, u32* flushed = 0);
+
+	// Write a slot back so it can be reused. False means the data could not be
+	// written and the slot must be left where it is - the cache is the only
+	// copy, so evicting it anyway is data loss.
+	static bool EvictSlot(CacheSlot* victim);
 	static void NoteStall(u32 startMicros);
 
 	// A chunk being evicted can belong to a different disk, so we need to get

--- a/src/emulation/scsi.h
+++ b/src/emulation/scsi.h
@@ -86,6 +86,12 @@ public:
 	// The budget is time rather than chunks because a chunk is up to four
 	// separate writes when its dirty sectors are not contiguous, so a chunk
 	// count bounds the work only to within a factor of four.
+	//
+	// It is a SOFT budget. The deadline is tested before each write, and a
+	// write in progress cannot be abandoned, so a call can overrun by one
+	// access - 35ms at the worst rate measured here. A pass that empties the
+	// cache also ends with f_sync, which is another. Treat maxMicros as "stop
+	// starting new work after this", not as a hard ceiling.
 	static int FlushSome(u32 maxMicros);
 
 	// Quarter of a second: unnoticeable on top of the host's own reset, and
@@ -149,7 +155,7 @@ private:
 	// something else, and by Sync.
 	// Both return 0 on success. A chunk that fails keeps its dirty bits so the
 	// next flush tries again rather than dropping the data on the floor.
-	int FlushChunk(CacheSlot& slot);
+	int FlushChunk(CacheSlot& slot, u32 deadline = 0);
 	int FlushAllDirty(u32 deadline = 0);
 
 	// Whether this image still has chunks waiting to be written. Read only -


### PR DESCRIPTION
Four ways acknowledged writes could still go missing, all on paths PR #7 did not cover. That PR fixed the write path and left the ways data *leaves* the cache untouched.

### Eviction discarded what it could not write

`FindSlot` flushed the victim chunk, ignored the result, and cleared `dirtyMask` regardless — so a full or failing card lost the data anyway, with no error latched and no CHECK CONDITION raised. A victim whose owning image had been detached was never flushed at all. This was the main path defeating #7's failure-preserving `FlushChunk`.

Eviction now reports whether the chunk actually went out. If not, the other way of the set is tried; if that is unwritable too, `FindSlot` returns nothing and `WriteSector` falls back to writing straight through — slow, but honest about failing.

### Detach threw away dirty chunks

It ignored `Sync`'s status, then closed the file and invalidated every slot for the image — discarding exactly what `Sync` had kept for retry. Now retries once (a first failure is usually transient) and says so loudly if that fails too.

### ReadSectorUncached returned uninitialised RAM

It checked the slot's `valid` flag but not the requested sector's `validMask` bit, unlike `ReadSector`. A chunk created by writing one sector holds uninitialised memory for the other seven — so the base-LBA scan, which reads uncached by design, could find a CMD signature that was never on the card.

### The reset flush was unbounded

Reset is a good moment to write back, but it is reached from the IEC RESET line as well as the front panel, and `WaitUntilReset` returns as soon as the host releases RESET — the computer is already running and about to poll a drive that cannot answer ATN while it talks to the card. 32MB of cache is 8192 chunks; at the 35ms per access measured on this hardware that is minutes.

It now flushes a bounded slice and leaves the rest to the idle path. **This one is a regression I introduced in #7** — after a heavy write, when the backlog is largest, it was plausibly worse than not flushing at all.

`Sync` grew a chunk budget for this, shared across images so the worst case stays bounded whatever is mounted, and only marks the cache clean when everything really went out.

### Testing

Builds clean for `RASPPI=3`. **Not hardware tested** — the interesting cases need a genuinely full or failing card, which I have not reproduced. The reset-bounding is the part most worth trying on real hardware, since it changes behaviour on every reset.

---

*Disclosure: written with Claude (Anthropic's Claude Code); the commit carries a `Co-Authored-By` trailer.*