### PR TITLE
Fix four ways to read or write out of bounds

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -189,6 +189,15 @@ void Options::Process(char* buffer)
 		/*char* equals = */GetToken();
 		char* pValue = GetToken();
 
+		// GetToken returns 0 at the end of the buffer, so a key with no value
+		// - a truncated file, or a trailing "Font =" - leaves pValue null. The
+		// decimal and float macros survive that because GetDecimal/GetFloat
+		// null-check, but the string options went straight into strncpy and
+		// took the Pi down at boot, before anything is on screen to say why.
+		// An option with no value is simply skipped.
+		if (!pValue)
+			continue;
+
 		if ((strcasecmp(pOption, "Font") == 0) || (strcasecmp(pOption, "ChargenFont") == 0))
 		{
 			strncpy(ROMFontName, pValue, 255);

--- a/src/options.h
+++ b/src/options.h
@@ -89,18 +89,42 @@ public:
 
 	inline float ScrollHighlightRate() const { return scrollHighlightRate; }
 
-	inline unsigned int GetButtonEnter() const { return buttonEnter - 1; }
-	inline unsigned int GetButtonUp() const { return buttonUp - 1; }
-	inline unsigned int GetButtonDown() const { return buttonDown - 1; }
-	inline unsigned int GetButtonBack() const { return buttonBack - 1; }
-	inline unsigned int GetButtonInsert() const { return buttonInsert - 1; }
+	// options.txt numbers the buttons 1-5; the arrays behind them are indexed
+	// from 0, hence the -1. An out of range value used to sail straight
+	// through: "buttonEnter = 0" gave 0u - 1 = 0xFFFFFFFF, truncated to 255
+	// when stored in a u8, and inputmappings then read 250 elements past the
+	// end of IEC_Bus's five element arrays.
+	//
+	// The two families need different handling. The CMD HD buttons are always
+	// tested with "< 5" before use, so out of range can map to a sentinel that
+	// disables the function - which is what options.txt already documents 0 to
+	// mean. The browser buttons are stored as u8 and indexed unguarded, so
+	// there is no disabled state available: they fall back to their default
+	// instead, which at least leaves the browser usable.
+	static const unsigned int BUTTON_DISABLED = 0xFFFFFFFF;
+
+	static inline unsigned int ButtonIndex(unsigned int n)
+	{
+		return (n >= 1 && n <= 5) ? n - 1 : BUTTON_DISABLED;
+	}
+
+	static inline unsigned int BrowserButtonIndex(unsigned int n, unsigned int fallback)
+	{
+		return (n >= 1 && n <= 5) ? n - 1 : fallback - 1;
+	}
+
+	inline unsigned int GetButtonEnter() const { return BrowserButtonIndex(buttonEnter, 1); }
+	inline unsigned int GetButtonUp() const { return BrowserButtonIndex(buttonUp, 2); }
+	inline unsigned int GetButtonDown() const { return BrowserButtonIndex(buttonDown, 3); }
+	inline unsigned int GetButtonBack() const { return BrowserButtonIndex(buttonBack, 4); }
+	inline unsigned int GetButtonInsert() const { return BrowserButtonIndex(buttonInsert, 5); }
 
 	// CMD HD front panel buttons (1-5 in options.txt, 0 = function disabled)
-	inline unsigned int GetCMDHDButtonSwap8() const { return CMDHDButtonSwap8 - 1; }
-	inline unsigned int GetCMDHDButtonSwap9() const { return CMDHDButtonSwap9 - 1; }
-	inline unsigned int GetCMDHDButtonWP() const { return CMDHDButtonWP - 1; }
-	inline unsigned int GetCMDHDButtonReset() const { return CMDHDButtonReset - 1; }
-	inline unsigned int GetCMDHDButtonExit() const { return CMDHDButtonExit - 1; }
+	inline unsigned int GetCMDHDButtonSwap8() const { return ButtonIndex(CMDHDButtonSwap8); }
+	inline unsigned int GetCMDHDButtonSwap9() const { return ButtonIndex(CMDHDButtonSwap9); }
+	inline unsigned int GetCMDHDButtonWP() const { return ButtonIndex(CMDHDButtonWP); }
+	inline unsigned int GetCMDHDButtonReset() const { return ButtonIndex(CMDHDButtonReset); }
+	inline unsigned int GetCMDHDButtonExit() const { return ButtonIndex(CMDHDButtonExit); }
 
 
 	// Page up and down will jump a different amount based on the maximum number rows displayed.

--- a/src/ui/filebrowser.cpp
+++ b/src/ui/filebrowser.cpp
@@ -529,7 +529,7 @@ FileBrowser::FileBrowser(InputMappings* inputMappings, const char* romName, bool
 {
 	selectedDHDPath[0] = 0;
 	selectedDHDReadOnly = false;
-	lastSelectionName = 0;
+	lastSelectionName[0] = 0;
 
 	folder.scrollHighlightRate = scrollHighlightRate;
 
@@ -1215,7 +1215,7 @@ void FileBrowser::UpdateInputFolders()
 					selectionsMade = FillCaddyWithSelections();
 
 					if (selectionsMade)
-						lastSelectionName = current->filImage.fname;
+						SetLastSelectionName(current->filImage.fname);
 
 					dirty = true;
 				}
@@ -1360,7 +1360,7 @@ void FileBrowser::SelectAutoMountImage(const char* image)
 		// selectionsMade true, and the browser loop then hands
 		// LastSelectionName() to BeginEmulating for the icon lookup. Without
 		// it that pointer was whatever the member happened to contain.
-		lastSelectionName = current->filImage.fname;
+		SetLastSelectionName(current->filImage.fname);
 		selectionsMade = FillCaddyWithSelections();
 	}
 }

--- a/src/ui/filebrowser.cpp
+++ b/src/ui/filebrowser.cpp
@@ -529,6 +529,7 @@ FileBrowser::FileBrowser(InputMappings* inputMappings, const char* romName, bool
 {
 	selectedDHDPath[0] = 0;
 	selectedDHDReadOnly = false;
+	lastSelectionName = 0;
 
 	folder.scrollHighlightRate = scrollHighlightRate;
 
@@ -1095,7 +1096,10 @@ void FileBrowser::DisplayDHDInfo(const char* imagePath, u32 sizeInSectors, const
 	{
 		RGBA BkColour = RGBA(0, 0, 0, 0xFF);
 		screenLCD->Clear(BkColour);
-		screenLCD->PrintText(false, 0, 0, (char*)filenameForIcon, RGBA(0xff, 0xff, 0xff, 0xff), BkColour);
+		// Belt and braces: callers should always pass a name, but this is the
+		// one place a stray pointer would be walked as a string.
+		if (filenameForIcon)
+			screenLCD->PrintText(false, 0, 0, (char*)filenameForIcon, RGBA(0xff, 0xff, 0xff, 0xff), BkColour);
 		screenLCD->SwapBuffers();
 	}
 }
@@ -1352,6 +1356,11 @@ void FileBrowser::SelectAutoMountImage(const char* image)
 	{
 		ClearSelections();
 		caddySelections.entries.push_back(*current);
+		// Has to be set here as well as on the manual path: this makes
+		// selectionsMade true, and the browser loop then hands
+		// LastSelectionName() to BeginEmulating for the icon lookup. Without
+		// it that pointer was whatever the member happened to contain.
+		lastSelectionName = current->filImage.fname;
 		selectionsMade = FillCaddyWithSelections();
 	}
 }

--- a/src/ui/filebrowser.h
+++ b/src/ui/filebrowser.h
@@ -19,6 +19,7 @@
 #ifndef FileBrowser_H
 #define FileBrowser_H
 #include <assert.h>
+#include <string.h>
 #include "ff.h"
 #include <vector>
 #include "types.h"
@@ -195,6 +196,16 @@ public:
 
 	bool SelectionsMade() { return selectionsMade; }
 	const char* LastSelectionName() { return lastSelectionName; }
+	void SetLastSelectionName(const char* name)
+	{
+		if (!name)
+		{
+			lastSelectionName[0] = 0;
+			return;
+		}
+		strncpy(lastSelectionName, name, sizeof(lastSelectionName) - 1);
+		lastSelectionName[sizeof(lastSelectionName) - 1] = 0;
+	}
 	void ClearSelections();
 
 	// DHD images are streamed from the SD card rather than loaded into RAM,
@@ -242,7 +253,12 @@ private:
 	bool selectionsMade;
 	char selectedDHDPath[512];
 	bool selectedDHDReadOnly;
-	const char* lastSelectionName;
+	// Owned, not borrowed. This used to point straight at a FILINFO inside
+	// folder.entries, which is only safe while nothing refreshes or reallocates
+	// that vector between the selection and the read of it. Nothing does today,
+	// but it is a dangling pointer waiting for someone to add a refresh, and a
+	// copy costs one buffer.
+	char lastSelectionName[_MAX_LFN + 1];
 	const char* romName;
 	bool displayPNGIcons;
 	bool buttonChangedROMDevice;

--- a/src/ui/ssd1306.cpp
+++ b/src/ui/ssd1306.cpp
@@ -118,10 +118,17 @@ void SSD1306::SendData(u8 data)
 	RPI_I2CWrite(BSCMaster, address, buffer, sizeof(buffer));
 }
 
-//We can send up to 16 bytes to the i2c bus
+// We can send up to 16 bytes to the i2c bus: one control byte plus fifteen of
+// data. The buffer has to be sixteen for that - it was fifteen, so a full
+// length 15 transfer wrote buffer[15] one past the end and then handed
+// RPI_I2CWrite a 16 byte count over a 15 byte buffer. That happened on any
+// display refresh with a run of 15 or more changed bytes.
 void SSD1306::SendDataLong(void* data, u8 length)
 {
-	char buffer[15];
+	char buffer[16];
+
+	if (length > sizeof(buffer) - 1)
+		length = sizeof(buffer) - 1;
 
 	buffer[0] = SSD1306_DATA_REG;
 	memcpy(&buffer[1], data, length);


### PR DESCRIPTION
None of these need an unusual setup — three of the four fire on the configuration the README recommends. Independent of #8; they touch different files.

### OLED transfer buffer was one byte too small

`SendDataLong`'s own comment says "one control byte plus fifteen of data" and then declares `char buffer[15]`. A full-length transfer writes `buffer[15]` one past the end, then hands `RPI_I2CWrite` a 16-byte count over a 15-byte buffer. The caller passes runs of up to 15, so this fires on **any display refresh with enough changed bytes** — continuously, on any board with an I2C panel.

### lastSelectionName was uninitialised on the auto-mount path

Never initialised in the constructor, and `SelectAutoMountImage` sets `selectionsMade` without setting it. Manual selection assigns it first so that path is fine — but the auto-mount path leaves it as whatever the member happened to contain, and the browser loop then passes it to `DisplayDHDInfo`, which hands it to `PrintText` to be walked as a string whenever an LCD is configured.

`AutoMountImage` + `LCDName` is the documented setup, so this is a wild pointer read on a normal boot. Now initialised, set on the auto-mount path, and `DisplayDHDInfo` tolerates a null.

### A key with no value crashed option parsing

`GetToken` returns 0 at end of buffer, so a truncated file or a trailing `Font =` left `pValue` null and the five string options passed it straight to `strncpy` — taking the Pi down at boot before anything is on screen to say why. The decimal/float macros survive because `GetDecimal`/`GetFloat` null-check, which is what made the omission easy to miss.

### Out-of-range button numbers indexed past the end

`buttonEnter = 0` — the way the CMD HD button options document disabling — gave `0u - 1` = `0xFFFFFFFF`, truncated to 255 in a `u8`, and inputmappings read 250 elements past `IEC_Bus`'s five-element arrays.

The two families needed different handling, and that part is worth a look during review: the CMD HD buttons are always tested `< 5`, so out-of-range can map to a disabled sentinel — which is what `options.txt` already documents `0` to mean. The browser buttons are stored as `u8` and indexed **unguarded**, so no disabled state is available; they fall back to their default instead.

### Testing

Builds clean for `RASPPI=3`. **Not hardware tested.** The OLED fix is the one most worth trying on a real panel, since it changes what gets sent on every refresh.

---

*Disclosure: written with Claude (Anthropic's Claude Code); the commit carries a `Co-Authored-By` trailer.*
