### PR TITLE
Actually tell the host why a command failed

### DIFF
--- a/src/emulation/picmdhd.cpp
+++ b/src/emulation/picmdhd.cpp
@@ -157,15 +157,16 @@ void cmdhd_scsiwrite(scsi_context_t* scsi)
 }
 
 // We don't actually format the disk, we just remove the 16 byte CMD signature
-void cmdhd_scsiformat(scsi_context_t* scsi)
+s32 cmdhd_scsiformat(scsi_context_t* scsi)
 {
 	PiCMDHD* hd = (PiCMDHD*)(scsi->p);
 	int i;
+	s32 result = 0;
 
 	// leave if we are not the first disk
 	if (scsi->target != 0 || scsi->lun != 0)
 	{
-		return;
+		return 0;
 	}
 
 	// figure out where to start looking
@@ -205,14 +206,17 @@ void cmdhd_scsiformat(scsi_context_t* scsi)
 			{
 				scsi->data_buf[0x1f0 + i] = 0;
 			}
-			// write it back
-			scsi_image_write(scsi);
+			// write it back. If that fails the signature is still there and
+			// the disk is not formatted, so say so rather than reporting a
+			// successful FORMAT UNIT over an untouched disk.
+			result = scsi_image_write(scsi);
 			break;
 		}
 		// otherwise, keep looking
 		scsi->address += 128;
 	}
 	hd->scanTotal = 0;
+	return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/emulation/picmdhd.cpp
+++ b/src/emulation/picmdhd.cpp
@@ -162,18 +162,29 @@ s32 cmdhd_scsiformat(scsi_context_t* scsi)
 	PiCMDHD* hd = (PiCMDHD*)(scsi->p);
 	int i;
 
-	// Nothing has been done yet, so the default is failure. Only zeroing the
-	// signature counts as having formatted the disk - an empty image, a read
-	// that failed part way through the scan, or a scan that ran to the end
-	// without finding a signature all leave the disk exactly as it was, and
-	// reporting GOOD for those is how FORMAT UNIT came to succeed over disks
-	// it had never touched.
-	s32 result = -1;
+	// What FORMAT UNIT is being asked for here is "leave no CMD signature on
+	// this disk", so the three outcomes are:
+	//
+	//   signature found and erased        - done, success
+	//   scanned the whole disk, none there - already true, success
+	//   could not look, or could not erase - failure
+	//
+	// The middle case matters: a fresh blank image has no signature, and
+	// formatting one is exactly what installing a new drive does. Reporting
+	// failure there would break it.
+	s32 result = 0;
 
-	// leave if we are not the first disk
+	// leave if we are not the first disk - nothing to do, which is not a
+	// failure
 	if (scsi->target != 0 || scsi->lun != 0)
 	{
 		return 0;
+	}
+
+	// An image with no size cannot be scanned, let alone formatted.
+	if (hd->imagesize == 0)
+	{
+		return -1;
 	}
 
 	// figure out where to start looking
@@ -199,9 +210,12 @@ s32 cmdhd_scsiformat(scsi_context_t* scsi)
 	while (scsi->address < hd->imagesize)
 	{
 		hd->scanSector = scsi->address;
-		// stop if we hit the end of the file
+		// stop if we hit the end of the file. The scan is incomplete, so
+		// whether a signature is present is now unknown - that is a failure,
+		// not a clean sweep.
 		if (scsi_image_read_uncached(scsi) < 0)
 		{
+			result = -1;
 			break;
 		}
 		// check for the CMD sig

--- a/src/emulation/picmdhd.cpp
+++ b/src/emulation/picmdhd.cpp
@@ -161,7 +161,14 @@ s32 cmdhd_scsiformat(scsi_context_t* scsi)
 {
 	PiCMDHD* hd = (PiCMDHD*)(scsi->p);
 	int i;
-	s32 result = 0;
+
+	// Nothing has been done yet, so the default is failure. Only zeroing the
+	// signature counts as having formatted the disk - an empty image, a read
+	// that failed part way through the scan, or a scan that ran to the end
+	// without finding a signature all leave the disk exactly as it was, and
+	// reporting GOOD for those is how FORMAT UNIT came to succeed over disks
+	// it had never touched.
+	s32 result = -1;
 
 	// leave if we are not the first disk
 	if (scsi->target != 0 || scsi->lun != 0)

--- a/src/emulation/picmdhd.h
+++ b/src/emulation/picmdhd.h
@@ -161,7 +161,7 @@ public:
 private:
 	friend void cmdhd_scsiread(scsi_context_t* scsi);
 	friend void cmdhd_scsiwrite(scsi_context_t* scsi);
-	friend void cmdhd_scsiformat(scsi_context_t* scsi);
+	friend s32 cmdhd_scsiformat(scsi_context_t* scsi);
 
 	void FindBaseLBA();
 	void UpdateButtonInputs();

--- a/src/emulation/scsi.cpp
+++ b/src/emulation/scsi.cpp
@@ -608,6 +608,24 @@ static u32 scsi_getmaxsize(scsi_context_t* context)
 	return 0;
 }
 
+// A background flush failed since the last command was processed. The host was
+// told that write succeeded and cannot be told otherwise, so it gets reported
+// against whatever comes next.
+//
+// Against ANY next command, not just another write: a host that has finished
+// writing may well only ever read again, or just poll TEST UNIT READY, and the
+// failure would then never surface at all.
+static s32 scsi_imagecheck(scsi_context_t* context);
+
+static bool scsi_take_deferred_write_error(scsi_context_t* context)
+{
+	if (scsi_imagecheck(context))
+		return false;
+
+	ScsiImage* image = context->file[(context->target << 3) | context->lun];
+	return image && image->TakeWriteError();
+}
+
 static s32 scsi_imagecheck(scsi_context_t* context)
 {
 	if (context->target >= MAXIDS || context->lun >= MAXLUNS)
@@ -1046,16 +1064,28 @@ void scsi_process_ack(scsi_context_t* context)
 				case SCSI_COMMAND_TEST_UNIT_READY:
 					context->lun = (context->cmd_buf[1] >> 5) & 7;
 					context->link = context->cmd_buf[5] & 1;
+					context->state = SCSI_STATE_STATUS;
 					if (scsi_imagecheck(context))
 					{
-						context->sensekey = SCSI_SENSEKEY_ILLEGALREQUEST;
+						// Nothing attached is NOT READY / medium not present,
+						// not ILLEGAL REQUEST - and it used to set no ASC at
+						// all, so the sense described the previous command.
+						context->sensekey = SCSI_SENSEKEY_NOTREADY;
+						context->asc = SCSI_SASC_MEDIUMNOTPRESENT;
 						context->status = SCSI_STATUS_CHECKCONDITION;
-						context->state = SCSI_STATE_STATUS;
+					}
+					else if (scsi_take_deferred_write_error(context))
+					{
+						// This is the command a host polls with, so it is the
+						// one most likely to be the first thing issued after
+						// the writing has finished.
+						context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
+						context->asc = SCSI_SASC_WRITEFAULT;
+						context->status = SCSI_STATUS_CHECKCONDITION;
 					}
 					else
 					{
 						context->status = SCSI_STATUS_GOOD;
-						context->state = SCSI_STATE_STATUS;
 					}
 					break;
 				case SCSI_COMMAND_REQUEST_SENSE:
@@ -1077,6 +1107,11 @@ void scsi_process_ack(scsi_context_t* context)
 					context->data_buf[0] = 0x80 | 0x70;
 					context->data_buf[1] = 0x00;
 					context->data_buf[2] = context->sensekey;
+					// Additional sense length: the count of bytes after byte 7.
+					// Eighteen byte fixed format sense means 10. It was left at
+					// zero, which tells a compliant initiator that byte 12 -
+					// the ASC it is being handed - is not there.
+					context->data_buf[7] = 10;
 					context->data_buf[12] = context->asc;
 					context->status = SCSI_STATUS_GOOD;
 
@@ -1132,10 +1167,31 @@ void scsi_process_ack(scsi_context_t* context)
 						}
 					}
 					context->data_max = 512;
+
+					// "Is there a disk" before "is that block on the disk".
+					// The other way round, an absent image has a maximum size
+					// of zero, so every LBA failed as out of range and the
+					// medium-not-present case was unreachable.
+					if (scsi_imagecheck(context))
+					{
+						context->sensekey = SCSI_SENSEKEY_NOTREADY;
+						context->asc = SCSI_SASC_MEDIUMNOTPRESENT;
+						context->status = SCSI_STATUS_CHECKCONDITION;
+						context->state = SCSI_STATE_STATUS;
+						break;
+					}
 					if (context->address >= scsi_getmaxsize(context))
 					{
 						context->sensekey = SCSI_SENSEKEY_ILLEGALREQUEST;
 						context->asc = SCSI_SASC_LOGICALBLOCKADDRESSOUTOFRANGE;
+						context->status = SCSI_STATUS_CHECKCONDITION;
+						context->state = SCSI_STATE_STATUS;
+						break;
+					}
+					if (scsi_take_deferred_write_error(context))
+					{
+						context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
+						context->asc = SCSI_SASC_WRITEFAULT;
 						context->status = SCSI_STATUS_CHECKCONDITION;
 						context->state = SCSI_STATE_STATUS;
 						break;
@@ -1186,6 +1242,18 @@ void scsi_process_ack(scsi_context_t* context)
 						}
 					}
 					context->data_max = 512;
+
+					// Same ordering point as the read path: without this, an absent image
+					// has a maximum size of zero so every LBA fails as out of range and
+					// the medium-not-present case below is unreachable.
+					if (scsi_imagecheck(context))
+					{
+						context->sensekey = SCSI_SENSEKEY_NOTREADY;
+						context->asc = SCSI_SASC_MEDIUMNOTPRESENT;
+						context->status = SCSI_STATUS_CHECKCONDITION;
+						context->state = SCSI_STATE_STATUS;
+						break;
+					}
 					if (context->address >= scsi_getmaxsize(context))
 					{
 						context->sensekey = SCSI_SENSEKEY_ILLEGALREQUEST;

--- a/src/emulation/scsi.cpp
+++ b/src/emulation/scsi.cpp
@@ -610,11 +610,15 @@ static u32 scsi_getmaxsize(scsi_context_t* context)
 
 // A background flush failed since the last command was processed. The host was
 // told that write succeeded and cannot be told otherwise, so it gets reported
-// against whatever comes next.
+// against a later command instead.
 //
-// Against ANY next command, not just another write: a host that has finished
-// writing may well only ever read again, or just poll TEST UNIT READY, and the
-// failure would then never surface at all.
+// Called from TEST UNIT READY, READ and WRITE - not from every command. Those
+// three are what a host actually does after writing (and TEST UNIT READY is
+// what it polls with), so the failure surfaces promptly in practice. The
+// commands that do not check - READ CAPACITY, MODE SENSE and friends - are
+// ones a host issues about the device rather than about its data, and adding
+// the check there would report a data error in answer to a question that was
+// not about data.
 static s32 scsi_imagecheck(scsi_context_t* context);
 
 static bool scsi_take_deferred_write_error(scsi_context_t* context)

--- a/src/emulation/scsi.cpp
+++ b/src/emulation/scsi.cpp
@@ -453,12 +453,6 @@ int ScsiImage::WriteSector(u32 lba, const u8* buffer)
 	if (!attached || readOnly)
 		return -1;
 
-	// A deferred flush failed since the last command. The host was told that
-	// write succeeded and cannot be told otherwise now, so report the error
-	// here instead - once - and let HDOS surface it. The data itself is still
-	// dirty in the cache and will be retried.
-	if (TakeWriteError())
-		return -1;
 
 	if (lba >= sizeInSectors)
 		return -1;
@@ -708,7 +702,8 @@ s32 scsi_image_write(scsi_context_t* context)
 
 /* default format handler */
 /* We don't actually format the disk, we just zero out the first sector */
-static void scsi_format_sector0(scsi_context_t* context)
+/* Returns 0 on success, non-zero if the write did not happen. */
+static s32 scsi_format_sector0(scsi_context_t* context)
 {
 	s32 i;
 
@@ -719,7 +714,10 @@ static void scsi_format_sector0(scsi_context_t* context)
 		context->data_buf[i] = 0;
 	}
 
-	scsi_image_write(context);
+	// The result matters: on read-only media or a failing card this write does
+	// not happen, and reporting FORMAT UNIT as successful when the disk is
+	// untouched is worse than reporting the failure.
+	return scsi_image_write(context);
 }
 
 u8 scsi_get_bus(scsi_context_t* context)
@@ -887,12 +885,26 @@ void scsi_process_ack(scsi_context_t* context)
 					context->command == SCSI_COMMAND_WRITE_10 ||
 					context->command == SCSI_COMMAND_WRITE_VERIFY)
 				{
-					if (scsi_image_write(context))
+					// A deferred flush failed since the last host command. The
+					// computer was told that earlier write succeeded and cannot
+					// be told otherwise now, so report it against this one and
+					// let HDOS surface it. The data is still dirty in the cache
+					// and will be retried.
+					//
+					// This is checked here rather than inside WriteSector so
+					// that the drive's own internal writes - the base LBA scan,
+					// the format handler - cannot consume the latched error
+					// before the host ever sees it.
+					ScsiImage* img = scsi_imagecheck(context) ? 0 :
+						context->file[(context->target << 3) | context->lun];
+
+					if (scsi_image_write(context) || (img && img->TakeWriteError()))
 					{
 						// Say why, so REQUEST SENSE returns something
 						// meaningful instead of whatever was left over from
 						// the last command.
 						context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
+						context->asc = SCSI_SASC_WRITEFAULT;
 						context->status = SCSI_STATUS_CHECKCONDITION;
 						context->state = SCSI_STATE_STATUS;
 						break;
@@ -937,9 +949,21 @@ void scsi_process_ack(scsi_context_t* context)
 					}
 					else
 					{
-						context->status = SCSI_STATUS_GOOD;
+						// Run the handler first and report what it did. This used to set
+						// GOOD before calling it and ignore the result, so a format that
+						// never touched the disk - read only media, a failing card -
+						// still looked like a success.
 						context->state = SCSI_STATE_STATUS;
-						context->user_format(context);
+						if (context->user_format(context))
+						{
+							context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
+							context->asc = SCSI_SASC_WRITEFAULT;
+							context->status = SCSI_STATUS_CHECKCONDITION;
+						}
+						else
+						{
+							context->status = SCSI_STATUS_GOOD;
+						}
 					}
 				}
 				else if (context->command == SCSI_COMMAND_REASSIGN_BLOCKS)
@@ -1055,7 +1079,21 @@ void scsi_process_ack(scsi_context_t* context)
 					context->data_buf[2] = context->sensekey;
 					context->data_buf[12] = context->asc;
 					context->status = SCSI_STATUS_GOOD;
-					context->state = SCSI_STATE_STATUS;
+
+					// Hand the sense data back, rather than going straight to
+					// STATUS with GOOD and never sending it. Building the
+					// eighteen bytes and then dropping them meant the host
+					// could tell that a command had failed but never why -
+					// every CHECK CONDITION in this file was effectively
+					// reasonless.
+					context->state = SCSI_STATE_DATAIN;
+					context->seq = 0;
+
+					// Sense is consumed by reading it. Leaving it latched
+					// makes the next REQUEST SENSE describe an error that has
+					// already been reported and dealt with.
+					context->sensekey = SCSI_SENSEKEY_NOSENSE;
+					context->asc = 0;
 					break;
 				case SCSI_COMMAND_REASSIGN_BLOCKS:
 					context->state = SCSI_STATE_DATAOUT;
@@ -1109,6 +1147,8 @@ void scsi_process_ack(scsi_context_t* context)
 					}
 					else
 					{
+						context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
+						context->asc = SCSI_SASC_UNRECOVEREDREADERROR;
 						context->status = SCSI_STATUS_CHECKCONDITION;
 						context->state = SCSI_STATE_STATUS;
 					}
@@ -1161,6 +1201,11 @@ void scsi_process_ack(scsi_context_t* context)
 					}
 					else
 					{
+						// No image attached at that target/LUN, which is a
+						// different thing from a media error and worth saying
+						// so - HDOS can tell "no disk" from "bad disk".
+						context->sensekey = SCSI_SENSEKEY_NOTREADY;
+						context->asc = SCSI_SASC_MEDIUMNOTPRESENT;
 						context->status = SCSI_STATUS_CHECKCONDITION;
 						context->state = SCSI_STATE_STATUS;
 					}
@@ -1291,9 +1336,17 @@ void scsi_process_ack(scsi_context_t* context)
 					}
 					else if ((context->cmd_buf[1] & 0x17) == 0x00)
 					{
-						context->status = SCSI_STATUS_GOOD;
 						context->state = SCSI_STATE_STATUS;
-						context->user_format(context);
+						if (context->user_format(context))
+						{
+							context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
+							context->asc = SCSI_SASC_WRITEFAULT;
+							context->status = SCSI_STATUS_CHECKCONDITION;
+						}
+						else
+						{
+							context->status = SCSI_STATUS_GOOD;
+						}
 					}
 					else
 					{
@@ -1355,6 +1408,11 @@ void scsi_process_ack(scsi_context_t* context)
 					/* read it, report error if a problem */
 					if (scsi_image_read(context))
 					{
+						// As on the write path: set the sense as well as the
+						// status, or REQUEST SENSE describes whatever the last
+						// command left behind.
+						context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
+						context->asc = SCSI_SASC_UNRECOVEREDREADERROR;
 						context->status = SCSI_STATUS_CHECKCONDITION;
 						context->state = SCSI_STATE_STATUS;
 						break;

--- a/src/emulation/scsi.h
+++ b/src/emulation/scsi.h
@@ -200,9 +200,13 @@ private:
 #define SCSI_STATUS_CHECKCONDITION           0x01
 
 #define SCSI_SENSEKEY_NOSENSE        0x00
+#define SCSI_SENSEKEY_NOTREADY       0x02
 #define SCSI_SENSEKEY_MEDIUMERROR    0x03
 #define SCSI_SENSEKEY_ILLEGALREQUEST 0x05
 
+#define SCSI_SASC_WRITEFAULT                    0x03
+#define SCSI_SASC_UNRECOVEREDREADERROR          0x11
+#define SCSI_SASC_MEDIUMNOTPRESENT              0x3A
 #define SCSI_SASC_LOGICALBLOCKADDRESSOUTOFRANGE 0x21
 #define SCSI_SASC_INVALIDFIELDINCDB             0x24
 #define SCSI_SASC_INVALIDFIELDINPARAMETERLIST   0x26
@@ -263,7 +267,10 @@ typedef struct scsi_context_s
 	u32 log;
 	ScsiImage* file[SCSI_MAX_DISKS];
 	void* p;
-	void (*user_format)(struct scsi_context_s*);
+	// Returns 0 on success. FORMAT UNIT used to report GOOD whatever the
+	// handler did, so a format onto read-only media or a failing card looked
+	// like it had worked.
+	s32 (*user_format)(struct scsi_context_s*);
 	void (*user_read)(struct scsi_context_s*);
 	void (*user_write)(struct scsi_context_s*);
 } scsi_context_t;


### PR DESCRIPTION
The drive could report that something went wrong but never what, so every `CHECK CONDITION` in the file was effectively reasonless. Follow-on from #7/#8 — those made errors *happen* correctly; this makes them *visible*.

### REQUEST SENSE never sent its answer

It fills in the eighteen-byte sense block and then goes to `SCSI_STATE_STATUS` with `GOOD`, instead of `SCSI_STATE_DATAIN`. The bytes were built and dropped.

That is the channel every other error path depends on — which means the `MEDIUM ERROR` added in #7 for failed writes **could never have been seen by anything.** It now returns the data, and clears the sense afterwards: sense is consumed by reading it, and leaving it latched makes the next `REQUEST SENSE` describe an error already dealt with.

### Four CHECK CONDITION sites set no sense at all

They set only `status`, leaving `sensekey`/`asc` holding whatever the *previous* command put there — so a failed write could be reported as "logical block address out of range" because that is what happened several commands ago.

Now: failed reads and writes report `MEDIUM ERROR` with an unrecovered-read-error or write-fault ASC, and a command against a target with nothing attached reports `NOT READY` / medium-not-present, which is a genuinely different condition and worth HDOS being able to tell apart.

All 15 `CHECK CONDITION` sites now set sense.

### Internal writes could swallow the latched flush error

The check for a failed background flush lived in `WriteSector`, so the drive's *own* writes — the base-LBA scan, the format handler — could consume it before the host ever saw it. Both of those ignore their return value, so it vanished silently.

It now sits on the host write path in the state machine, where only a real `WRITE` command can take it.

### FORMAT UNIT reported success whatever happened

Both call sites set `GOOD` *before* invoking the handler and ignored the result, and both handlers ignored the write underneath them. On read-only media or a failing card, a format that never touched the disk looked like it had worked.

`user_format` returns a status now and the call sites report it.

### Testing

Builds clean for `RASPPI=3`. **Not hardware tested.** This one changes what the drive says on the wire in error cases, so it is worth exercising against a real HDOS — though provoking the error paths still needs a card that actually fails.

Worth review: clearing sense after `REQUEST SENSE` is correct per spec but is a behaviour change, and the `NOT READY` distinction is a judgement call about what HDOS does with it.

---

*Disclosure: written with Claude (Anthropic's Claude Code); the commit carries a `Co-Authored-By` trailer.*
