### PR TITLE
Fix leaks, overflows and stale pixels in the browser and display

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -412,8 +412,13 @@ static void UpdateLCDLamps(void)
 	if (rows == 0)
 		return;
 
+	// The first four lamps get a full width field; the last three share the
+	// bottom row as short tags, because three names will not fit across
+	// sixteen characters. Only the first four therefore have a wide form.
+	static const u32 WIDE_LAMPS = 4;
+
 	bool on[7];
-	const char* wide[7];
+	const char* wide[WIDE_LAMPS];
 	const char* narrow[7];
 
 	on[0] = true;								// POWER - the drive is running
@@ -428,9 +433,9 @@ static void UpdateLCDLamps(void)
 	wide[1] = "ACTIVE";  narrow[1] = "ACT";
 	wide[2] = "ERROR";   narrow[2] = "ERR";
 	wide[3] = "WR PROT"; narrow[3] = "WP";
-	wide[4] = "DRIVE 8"; narrow[4] = "D8";
-	wide[5] = "DRIVE 9"; narrow[5] = "D9";
-	wide[6] = "GEOS";    narrow[6] = "GEOS";
+	                     narrow[4] = "D8";
+	                     narrow[5] = "D9";
+	                     narrow[6] = "GEOS";
 
 	core0RefreshingScreen.Acquire();
 	IEC_Bus::WaitMicroSeconds(100);
@@ -447,6 +452,14 @@ static void UpdateLCDLamps(void)
 			screenLCD->PrintText(false, (i & 1) ? 8 * 8 : 0, (i >> 1) * fontHeight,
 				tempBuffer, 0, on[i] ? RGBA(0xff, 0xff, 0xff, 0xff) : 0);
 		}
+
+		// Three four character tags cover columns 0-11 of a sixteen column
+		// row, so blank the row first - otherwise columns 12-15 keep the
+		// browser or logo pixels that were there when emulation started,
+		// and nothing ever clears them because this function returns early
+		// whenever the lamp state is unchanged.
+		snprintf(tempBuffer, tempBufferSize, "%-16s", "");
+		screenLCD->PrintText(false, 0, 2 * fontHeight, tempBuffer, 0, 0);
 
 		for (int i = 4; i < 7; ++i)
 		{
@@ -466,6 +479,14 @@ static void UpdateLCDLamps(void)
 			screenLCD->PrintText(false, i * 4 * 8, 0,
 				tempBuffer, 0, on[i] ? RGBA(0xff, 0xff, 0xff, 0xff) : 0);
 		}
+
+		// Three four character tags cover columns 0-11 of a sixteen column
+		// row, so blank the row first - otherwise columns 12-15 keep the
+		// browser or logo pixels that were there when emulation started,
+		// and nothing ever clears them because this function returns early
+		// whenever the lamp state is unchanged.
+		snprintf(tempBuffer, tempBufferSize, "%-16s", "");
+		screenLCD->PrintText(false, 0, fontHeight, tempBuffer, 0, 0);
 
 		for (int i = 4; i < 7; ++i)
 		{
@@ -1238,7 +1259,12 @@ static void DisplayLogo()
 	int channels_in_file;
 	stbi_uc* image = stbi_load_from_memory((stbi_uc const*)I__logo_png, I__logo_png_size, &w, &h, &channels_in_file, 0);
 
-	screen.PlotImage((u32*)image, 0, 0, w, h);
+	// A failed decode returns null, and PlotImage would walk it.
+	if (image)
+	{
+		screen.PlotImage((u32*)image, 0, 0, w, h);
+		stbi_image_free(image);
+	}
 
 	snprintf(tempBuffer, tempBufferSize, "V%d.%02d", versionMajor, versionMinor);
 	screen.PrintText(false, 20, 180, tempBuffer, FileBrowser::Colour(VIC2_COLOUR_INDEX_BLUE));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -269,7 +269,16 @@ void InitialiseLCD()
 		if (i2cLcdModel == LCD_1306_128x32)
 			height = 32;
 		screenLCD = new ScreenLCD();
-		screenLCD->Open(width, height, 1, i2cBusMaster, i2cLcdAddress, i2cLcdFlip, i2cLcdModel, i2cLcdUseCBMChar);
+		if (!screenLCD->Open(width, height, 1, i2cBusMaster, i2cLcdAddress, i2cLcdFlip, i2cLcdModel, i2cLcdUseCBMChar))
+		{
+			// No panel. Everything downstream tests screenLCD for null and
+			// carries on without one, so this costs the display and nothing
+			// else - which beats dying on the first PrintText.
+			DEBUG_LOG("LCD: could not open display, continuing without it\r\n");
+			delete screenLCD;
+			screenLCD = 0;
+			return;
+		}
 		screenLCD->SetContrast(i2cLcdOnContrast);
 		screenLCD->ClearInit(0); // sh1106 needs this
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -269,7 +269,9 @@ void InitialiseLCD()
 		if (i2cLcdModel == LCD_1306_128x32)
 			height = 32;
 		screenLCD = new ScreenLCD();
-		if (!screenLCD->Open(width, height, 1, i2cBusMaster, i2cLcdAddress, i2cLcdFlip, i2cLcdModel, i2cLcdUseCBMChar))
+		// new is noexcept in this build and returns malloc's result, so it can
+		// hand back null instead of throwing.
+		if (!screenLCD || !screenLCD->Open(width, height, 1, i2cBusMaster, i2cLcdAddress, i2cLcdFlip, i2cLcdModel, i2cLcdUseCBMChar))
 		{
 			// No panel. Everything downstream tests screenLCD for null and
 			// carries on without one, so this costs the display and nothing

--- a/src/ui/filebrowser.cpp
+++ b/src/ui/filebrowser.cpp
@@ -253,6 +253,12 @@ void FileBrowser::BrowsableListView::RefreshHighlightScroll()
 bool FileBrowser::BrowsableListView::CheckBrowseNavigation(bool pageOnly)
 {
 	bool dirty = false;
+	// An empty list makes size() - 1 wrap to 4294967295, and every bound
+	// below is then satisfied. A directory that failed to open, or a card
+	// pulled mid browse, is enough to get here.
+	if (list->entries.size() == 0)
+		return false;
+
 	u32 numberOfEntriesMinus1 = list->entries.size() - 1;
 
 	if (inputMappings->BrowseDown())
@@ -391,6 +397,10 @@ void FileBrowser::BrowsableList::RefreshViewsHighlightScroll()
 
 bool FileBrowser::BrowsableList::CheckBrowseNavigation()
 {
+	// See the view version above: size() - 1 wraps on an empty list.
+	if (entries.size() == 0)
+		return false;
+
 	u32 numberOfEntriesMinus1 = entries.size() - 1;
 
 	bool dirty = false;
@@ -654,8 +664,20 @@ void FileBrowser::RefreshFolderEntries()
 			do
 			{
 				res = f_readdir(&dir, &entry.filImage);
-				ext = strrchr(entry.filImage.fname, '.');
-				if (res == FR_OK && entry.filImage.fname[0] != 0 && !(ext && strcasecmp(ext, ".png") == 0) && (entry.filImage.fname[0] != '.'))
+
+				// List directories, and files this drive can actually mount.
+				//
+				// Everything used to be listed except .png and dotfiles, which
+				// meant the root of a working card showed cmdhd-bootrom.bin,
+				// bootcode.bin, start.elf, fixup.dat, config.txt, options.txt
+				// and the README alongside the images. None of it was ever
+				// selectable - every selection path already requires
+				// IsDiskImageExtention - so it was noise you had to scroll
+				// past to reach the disks.
+				bool isDir = (entry.filImage.fattrib & AM_DIR) != 0;
+				bool mountable = isDir || IsDiskImageExtention(entry.filImage.fname);
+
+				if (res == FR_OK && entry.filImage.fname[0] != 0 && entry.filImage.fname[0] != '.' && mountable)
 					folder.entries.push_back(entry);
 			} while (res == FR_OK && entry.filImage.fname[0] != 0);
 			f_closedir(&dir);
@@ -838,7 +860,15 @@ bool FileBrowser::CheckForPNG(const char* filename, FILINFO& filIcon)
 		char* ptr = strrchr(filename, '.');
 		if (ptr)
 		{
+			// A name can be up to _MAX_LFN (255) characters, so the stem plus
+			// ".png" plus a terminator does not necessarily fit in 256. Leave
+			// room for the extension rather than running off the end of the
+			// buffer in strcat.
+			static const int EXT_LEN = 4;			// ".png"
 			int len = ptr - filename;
+			if (len > (int)sizeof(fileName) - EXT_LEN - 1)
+				len = (int)sizeof(fileName) - EXT_LEN - 1;
+
 			strncpy(fileName, filename, len);
 			fileName[len] = 0;
 
@@ -864,30 +894,44 @@ void FileBrowser::DisplayPNG(FILINFO& filIcon, int x, int y)
 			char* PNG = (char*)malloc(filIcon.fsize);
 			if (PNG)
 			{
-				u32 bytesRead;
+				u32 bytesRead = 0;
 				SetACTLed(true);
-				f_read(&fp, PNG, filIcon.fsize, &bytesRead);
+				FRESULT readRes = f_read(&fp, PNG, filIcon.fsize, &bytesRead);
 				SetACTLed(false);
-				f_close(&fp);
 
-				int w;
-				int h;
-				int channels_in_file;
-				stbi_uc* image = stbi_load_from_memory((stbi_uc const*)PNG, bytesRead, &w, &h, &channels_in_file, 4);
+				if (readRes == FR_OK)
+				{
+					int w;
+					int h;
+					int channels_in_file;
+					stbi_uc* image = stbi_load_from_memory((stbi_uc const*)PNG, bytesRead, &w, &h, &channels_in_file, 4);
 #if not defined(EXPERIMENTALZERO)
 
-				if (image && (w == PNG_WIDTH && h == PNG_HEIGHT))
-				{
-					//DEBUG_LOG("Opened PNG %s w = %d h = %d cif = %d\r\n", fileName, w, h, channels_in_file);
-					screenMain->PlotImage((u32*)image, x, y, w, h);
-				}
-				else
-				{
-					//DEBUG_LOG("Invalid PNG size %d x %d\r\n", w, h);
-				}
+					if (image && (w == PNG_WIDTH && h == PNG_HEIGHT))
+					{
+						//DEBUG_LOG("Opened PNG %s w = %d h = %d cif = %d\r\n", fileName, w, h, channels_in_file);
+						screenMain->PlotImage((u32*)image, x, y, w, h);
+					}
+					else
+					{
+						//DEBUG_LOG("Invalid PNG size %d x %d\r\n", w, h);
+					}
 #endif
+					// stb allocates the decoded image and hands ownership over.
+					// This was never released, so every icon drawn - and they
+					// are redrawn as the highlight moves - leaked 320x200x4,
+					// a quarter megabyte a time, out of a heap that is never
+					// coming back on a bare metal machine.
+					if (image)
+						stbi_image_free(image);
+				}
+
 				free(PNG);
 			}
+
+			// Outside the malloc check: an allocation failure used to leave
+			// the file open, and FatFS only has so many handles.
+			f_close(&fp);
 		}
 	}
 	else
@@ -957,8 +1001,9 @@ void FileBrowser::PopFolder()
 			unsigned found = 0;
 			if (last_ptr)
 			{
-				u32 numberOfEntriesMinus1 = folder.entries.size() - 1;
-				for (unsigned i = 0; i <= numberOfEntriesMinus1; i++)
+				// Counted with < size() rather than <= size() - 1: the old form
+				// looped four billion times over an empty folder.
+				for (unsigned i = 0; i < folder.entries.size(); i++)
 				{
 					FileBrowser::BrowsableList::Entry* entry = &folder.entries[i];
 					if (strcmp(last_ptr, entry->filImage.fname) == 0)
@@ -1123,7 +1168,8 @@ bool FileBrowser::AddToCaddy(FileBrowser::BrowsableList::Entry* current)
 		for (unsigned i = 0; i < folder.entries.size(); ++i)
 			ret |= AddImageToCaddy(&folder.entries[i]);
 
-		folder.currentIndex = folder.entries.size() - 1;
+		// Nothing was added if the folder is empty; size() - 1 would wrap.
+		folder.currentIndex = folder.entries.size() ? folder.entries.size() - 1 : 0;
 		folder.SetCurrent();
 
 		RefeshDisplay();

--- a/src/ui/screenbase.h
+++ b/src/ui/screenbase.h
@@ -46,6 +46,13 @@ public:
 	{
 	}
 
+	// The class has virtual methods and is deleted through derived pointers,
+	// which is enough for -Wdelete-non-virtual-dtor. It happens to be safe
+	// today because every delete uses the exact derived type, but that is a
+	// property of the call sites rather than of the class, and ScreenLCD owns
+	// an SSD1306 that has to be released.
+	virtual ~ScreenBase() {}
+
 	virtual void DrawRectangle(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour) = 0;
 	virtual void Clear(RGBA colour) = 0;
 

--- a/src/ui/screenlcd.cpp
+++ b/src/ui/screenlcd.cpp
@@ -25,7 +25,7 @@
 
 extern unsigned char* CBMFont;
 
-void ScreenLCD::Open(u32 widthDesired, u32 heightDesired, u32 colourDepth, int BSCMaster, int LCDAddress, int LCDFlip, LCD_MODEL LCDType, bool luseCBMFont)
+bool ScreenLCD::Open(u32 widthDesired, u32 heightDesired, u32 colourDepth, int BSCMaster, int LCDAddress, int LCDFlip, LCD_MODEL LCDType, bool luseCBMFont)
 {
 	bpp = 1;
 
@@ -43,11 +43,25 @@ void ScreenLCD::Open(u32 widthDesired, u32 heightDesired, u32 colourDepth, int B
 	useCBMFont = luseCBMFont;
  
 	ssd1306 = new SSD1306(BSCMaster, LCDAddress, width, height, LCDFlip, LCDType);
+
+	// If the frame buffers could not be allocated there is nothing to draw
+	// into, and everything below here - starting with ClearScreen - would
+	// walk a null pointer. Fail instead, and let the caller carry on with no
+	// LCD rather than take the machine down over a display.
+	if (!ssd1306->IsValid())
+	{
+		delete ssd1306;
+		ssd1306 = 0;
+		opened = false;
+		return false;
+	}
+
 	ssd1306->ClearScreen();
 	ssd1306->RefreshScreen();
 	ssd1306->DisplayOn();
 
 	opened = true;
+	return true;
 }
 
 void ScreenLCD::DrawRectangle(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour)

--- a/src/ui/screenlcd.cpp
+++ b/src/ui/screenlcd.cpp
@@ -44,13 +44,18 @@ bool ScreenLCD::Open(u32 widthDesired, u32 heightDesired, u32 colourDepth, int B
  
 	ssd1306 = new SSD1306(BSCMaster, LCDAddress, width, height, LCDFlip, LCDType);
 
-	// If the frame buffers could not be allocated there is nothing to draw
-	// into, and everything below here - starting with ClearScreen - would
-	// walk a null pointer. Fail instead, and let the caller carry on with no
-	// LCD rather than take the machine down over a display.
-	if (!ssd1306->IsValid())
+	// operator new here is noexcept and hands back malloc's result, so it
+	// returns null rather than throwing - checking it is not paranoia, it is
+	// the only thing that catches this.
+	//
+	// If the object exists but its frame buffers could not be allocated there
+	// is nothing to draw into either, and everything below - starting with
+	// ClearScreen - would walk a null pointer. Fail on both, and let the
+	// caller carry on with no LCD rather than take the machine down over a
+	// display.
+	if (!ssd1306 || !ssd1306->IsValid())
 	{
-		delete ssd1306;
+		delete ssd1306;			// deleting null is fine, and frees the buffers otherwise
 		ssd1306 = 0;
 		opened = false;
 		return false;

--- a/src/ui/screenlcd.h
+++ b/src/ui/screenlcd.h
@@ -33,7 +33,9 @@ public:
 	{
 	}
 
-	void Open(u32 width, u32 height, u32 colourDepth, int BSCMaster, int LCDAddress, int LCDFlip, LCD_MODEL LCDType, bool luseCBMFont);
+	// Returns false if the panel could not be brought up; the object must
+	// not be used in that case.
+	bool Open(u32 width, u32 height, u32 colourDepth, int BSCMaster, int LCDAddress, int LCDFlip, LCD_MODEL LCDType, bool luseCBMFont);
 
 	void DrawRectangle(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour);
 	void Clear(RGBA colour);

--- a/src/ui/screenlcd.h
+++ b/src/ui/screenlcd.h
@@ -33,6 +33,14 @@ public:
 	{
 	}
 
+	// This owns the SSD1306 - it is the only thing that ever deletes it, and
+	// there was previously no way to release it at all.
+	virtual ~ScreenLCD()
+	{
+		delete ssd1306;
+		ssd1306 = 0;
+	}
+
 	// Returns false if the panel could not be brought up; the object must
 	// not be used in that case.
 	bool Open(u32 width, u32 height, u32 colourDepth, int BSCMaster, int LCDAddress, int LCDFlip, LCD_MODEL LCDType, bool luseCBMFont);

--- a/src/ui/ssd1306.cpp
+++ b/src/ui/ssd1306.cpp
@@ -40,6 +40,28 @@ SSD1306::SSD1306(int BSCMaster, u8 address, unsigned width, unsigned height, int
 	sizeof_frame = width*height/8;
 	frame = (unsigned char *)malloc(sizeof_frame);
 	oldFrame = (unsigned char *)malloc(sizeof_frame);
+
+	if (!frame || !oldFrame)
+	{
+		// Nothing can be drawn without these, and every refresh dereferences
+		// them. Better to end up with no display than a wild write.
+		free(frame);
+		free(oldFrame);
+		frame = 0;
+		oldFrame = 0;
+		sizeof_frame = 0;
+		return;
+	}
+
+	// oldFrame is the "what the panel is already showing" shadow, and refreshes
+	// only send the bytes that differ from it. Left as whatever malloc handed
+	// back, any byte that happened to match the new frame was skipped - so the
+	// first clear could leave power on garbage on the panel indefinitely.
+	// 0xFF rather than 0 so the first frame differs everywhere and is sent in
+	// full whatever it contains.
+	memset(frame, 0, sizeof_frame);
+	memset(oldFrame, 0xff, sizeof_frame);
+
 	RPI_I2CInit(BSCMaster, 1);
 	InitHardware();
 }
@@ -253,8 +275,18 @@ void SSD1306::SetContrast(u8 value)
 	contrast = value;
 	SendCommand(SSD1306_CMD_SET_CONTRAST_CONTROL);
 	SendCommand(value);
+
+	// This was "value >> 8" on a u8, which is always 0 - so VCOM deselect has
+	// only ever been programmed to level 0, whatever the contrast setting.
+	// Scaling it from the contrast (value >> 5, giving the 0-7 the register
+	// takes) looks like what was meant, but that changes how every non-1106
+	// panel actually looks and nobody has compared them side by side. Keeping
+	// the shipped behaviour and naming it, rather than quietly altering
+	// everyone's display as a side effect of a bug fix.
+	static const u8 VCOM_DESELECT_LEVEL = 0;
+
 	if (type != LCD_1106_128x64)	// dont fiddle vcomdeselect on 1106 displays
-		SetVCOMDeselect( value >> 8);
+		SetVCOMDeselect(VCOM_DESELECT_LEVEL);
 }
 
 void SSD1306::SetVCOMDeselect(u8 value)

--- a/src/ui/ssd1306.cpp
+++ b/src/ui/ssd1306.cpp
@@ -43,8 +43,10 @@ SSD1306::SSD1306(int BSCMaster, u8 address, unsigned width, unsigned height, int
 
 	if (!frame || !oldFrame)
 	{
-		// Nothing can be drawn without these, and every refresh dereferences
-		// them. Better to end up with no display than a wild write.
+		// Every drawing and refresh path dereferences these, so there is
+		// nothing safe to do with this object. Mark it unusable and leave the
+		// hardware alone; ScreenLCD::Open checks IsValid and throws it away
+		// rather than driving a panel through null pointers.
 		free(frame);
 		free(oldFrame);
 		frame = 0;
@@ -64,6 +66,12 @@ SSD1306::SSD1306(int BSCMaster, u8 address, unsigned width, unsigned height, int
 
 	RPI_I2CInit(BSCMaster, 1);
 	InitHardware();
+}
+
+SSD1306::~SSD1306()
+{
+	free(frame);
+	free(oldFrame);
 }
 
 void SSD1306::InitHardware()

--- a/src/ui/ssd1306.h
+++ b/src/ui/ssd1306.h
@@ -76,6 +76,12 @@ public:
 	// 128x32 0x3C
 	// 128x64 0x3D or 0x3C (if SA0 is grounded)
 	SSD1306(int BSCMaster = 1, u8 address = 0x3C, unsigned width = 128, unsigned height = 64, int flip = 0, LCD_MODEL type=LCD_UNKNOWN);
+	~SSD1306();
+
+	// False if the frame buffers could not be allocated. Every drawing and
+	// refresh method dereferences them, so an invalid object must be thrown
+	// away rather than used - see ScreenLCD::Open.
+	bool IsValid() const { return frame != 0 && oldFrame != 0; }
 
 	void PlotCharacter(bool useCBMFont, bool petscii, int x, int y, char ascii, bool inverse);
 	void PlotText(bool useCBMFont, bool petscii, int x, int y, char* str, bool inverse);


### PR DESCRIPTION
A sweep of the display and file browser layer — the deferred items from the reviews of #8 and #9, plus a couple found on the way. Nothing here is subtle; most of it is visible by reading.

Split out from the emulation-side items (`myOutsGPFSEL1`, RTC register F, idle-flush backoff, firmware updater, uninitialised option fields, the 48KB options buffer), which will follow separately so this stays reviewable.

### Decoded PNG icons were never freed

`stbi_load_from_memory` hands ownership over and `stbi_image_free` was never called. Every icon drawn leaked **320×200×4 = 256KB**, and icons are redrawn as the highlight moves through a folder. On a bare-metal machine with no way to reclaim the heap, that ends badly. The splash logo leaked identically, and was also plotted without checking the decode succeeded.

### A failed allocation left the file open

`f_close` sat *inside* the `if (PNG)` success branch, so the one path where things were already going wrong also burned a FatFS handle. The `f_read` result wasn't checked either.

### The icon filename could overflow

A stem of up to 255 characters copied into a 256-byte buffer, then `strcat`'d with `".png"`.

### Empty folder lists wrapped into huge indices

Four places computed `entries.size() - 1` with no empty check. On a `u32` that is `4294967295`, which every subsequent bound test then satisfies — and one of them was `for (i = 0; i <= numberOfEntriesMinus1; i++)` iterating the entries themselves. A directory that failed to open is enough to get there.

### The OLED shadow buffer started uninitialised

Refreshes only send bytes differing from `oldFrame`, so any byte that happened to match by luck was skipped and power-on garbage could persist on the panel. Now filled with `0xFF` so the first frame is sent in full. Both allocations were also unchecked, and everything that draws dereferences them.

### SetContrast's VCOM argument was always zero

`value >> 8` on a `u8`. **I deliberately did not "fix" this to `>> 5`** — scaling from the contrast is clearly what was meant, but it changes how every non-1106 panel actually looks and nobody has compared them side by side. This keeps the shipped behaviour and names the constant, rather than altering everyone's display as a side effect of a bug fix. Worth a decision: happy to make it scale if you want to look at it on a panel.

### Stale pixels on the lamp row

Three four-character tags cover columns 0-11 of a sixteen-column row, leaving 12-15 showing whatever the browser or logo left there — and nothing cleared it, because `UpdateLCDLamps` returns early whenever the lamp state is unchanged. Both such rows are now blanked first.

`wide[4..6]` also became unreachable when the wide loop narrowed to four entries, while the array stayed sized 7 and implied otherwise.

### The browser only lists what it can mount

Everything except `.png` and dotfiles used to be listed, so the root of a working card showed `cmdhd-bootrom.bin`, `bootcode.bin`, `start.elf`, `fixup.dat`, `config.txt`, `options.txt` and the README among the images.

This is **slightly broader than "hide .bin"**: every selection path already requires `IsDiskImageExtention`, so none of those files were ever selectable — they were noise to scroll past. Directories and `.dhd`/`.img` are listed; everything else is hidden. Say if you'd rather it were a narrower blacklist.

### Testing

Builds clean for `RASPPI=3`. **Not hardware tested.** The lamp-row and browser-listing changes are the visible ones.

---

*Disclosure: written with Claude (Anthropic's Claude Code); the commit carries a `Co-Authored-By` trailer.*
