### PR TITLE
Make CTRL_SYNC succeed, and stop USB offsets wrapping at 4GiB

### DIFF
--- a/src/rpi/diskio.cpp
+++ b/src/rpi/diskio.cpp
@@ -157,9 +157,15 @@ DRESULT disk_read (
 	}
 	else
 	{
-		unsigned bytes = (unsigned)USPiMassStorageDeviceRead((unsigned long long )(sector << UMSD_BLOCK_SHIFT), buff, count << UMSD_BLOCK_SHIFT, pdrv - 1);
+		// Widen before shifting, not after. sector is a 32 bit DWORD, so
+		// "(unsigned long long)(sector << SHIFT)" does the shift in 32 bits
+		// and casts the result that has already overflowed - sector 8388608
+		// lands at byte offset 0. The cast has to be on the operand.
+		unsigned long long offset = ((unsigned long long)sector) << UMSD_BLOCK_SHIFT;
+		unsigned wanted = count << UMSD_BLOCK_SHIFT;
+		unsigned bytes = (unsigned)USPiMassStorageDeviceRead(offset, buff, wanted, pdrv - 1);
 
-		if (bytes != (count << UMSD_BLOCK_SHIFT))
+		if (bytes != wanted)
 			return RES_ERROR;
 
 		return RES_OK;
@@ -196,10 +202,13 @@ DRESULT disk_write (
 	}
 	else
 	{
-		unsigned bytes = (unsigned)USPiMassStorageDeviceWrite(sector << UMSD_BLOCK_SHIFT, buff, count << UMSD_BLOCK_SHIFT, pdrv - 1);
+		// Same widening as disk_read - this one did not even have the cast.
+		unsigned long long offset = ((unsigned long long)sector) << UMSD_BLOCK_SHIFT;
+		unsigned wanted = count << UMSD_BLOCK_SHIFT;
+		unsigned bytes = (unsigned)USPiMassStorageDeviceWrite(offset, buff, wanted, pdrv - 1);
 
 		//DEBUG_LOG("USB disk_write %d %d\r\n", (int)sector, (int)count);
-		if (bytes != (count << UMSD_BLOCK_SHIFT))
+		if (bytes != wanted)
 			return RES_ERROR;
 
 		return RES_OK;
@@ -220,6 +229,24 @@ DRESULT disk_ioctl (
 	void *buff		/* Buffer to send/receive control data */
 )
 {
+	// CTRL_SYNC has to succeed. Both drivers behind this are synchronous -
+	// sd_write and USPiMassStorageDeviceWrite have finished with the media by
+	// the time they return - so there is no deferred write to push out and
+	// nothing to do.
+	//
+	// Returning RES_PARERR for it meant sync_fs turned every f_sync into
+	// FR_DISK_ERR (ff.cpp: "if (disk_ioctl(fs->drv, CTRL_SYNC, 0) != RES_OK)
+	// res = FR_DISK_ERR"). That was harmless while nothing checked f_sync's
+	// result, but the disk cache now treats a failed sync as a lost write, so
+	// every successful flush was being reported as a write error - which then
+	// latched, and came back to the computer as CHECK CONDITION on its next
+	// command. f_close was failing to finish cleanly for the same reason.
+	//
+	// With _MIN_SS == _MAX_SS and mkfs and trim both disabled in ffconf.h,
+	// this is the only ioctl FatFS ever issues; the rest stay unsupported.
+	if (cmd == CTRL_SYNC)
+		return RES_OK;
+
 	//DRESULT res;
 	//int result;
 


### PR DESCRIPTION
**This one is urgent** — the first bug is live on any card built from current `main`, and it was introduced by the cache work in #7/#8 interacting with a pre-existing stub.

### f_sync has never succeeded on this hardware

`disk_ioctl` returns `RES_PARERR` for everything, `CTRL_SYNC` included. `sync_fs` turns that straight into `FR_DISK_ERR`:

```c
/* Make sure that no pending write process in the physical drive */
if (disk_ioctl(fs->drv, CTRL_SYNC, 0) != RES_OK) res = FR_DISK_ERR;
```

That was harmless while nothing checked `f_sync`'s result. It is **not** harmless now, because #7 made the cache treat a failed sync as data it could not write. So every *successful* flush has been counted as a write failure, which then:

- latches `writeErrorPending`, so the next host command gets `CHECK CONDITION` / `MEDIUM ERROR` (#10)
- lights `WRITE FAIL` on the status line (#12)
- holds `needSync` set, so the same chunks are re-flushed on every idle window
- backs the idle retry off to ~32s immediately (#12)
- makes `Detach` announce `DATA LOST` on a perfectly clean unmount

Both drivers underneath are synchronous — `sd_write` and `USPiMassStorageDeviceWrite` are done with the media by the time they return — so `CTRL_SYNC` has nothing to do and `RES_OK` is honest rather than a fudge. With `_MIN_SS == _MAX_SS`, `_USE_MKFS 0` and `_USE_TRIM 0` in `ffconf.h`, it is also the **only** ioctl FatFS ever issues, so nothing else changes.

### USB offsets wrap at 4GiB

```c
(unsigned long long)(sector << UMSD_BLOCK_SHIFT)   // shifts in 32 bits, then widens
```

`sector` is a 32-bit `DWORD`, so the shift overflows before the cast can help. Sector 8388608 lands at byte offset zero — above 4GiB, reads return the wrong data and writes corrupt the start of the volume. The cast belongs on the operand. `disk_write` had no cast at all.

Only affects USB mass storage, not the SD card.

### Testing

Pi 3 (362616) and Pi Zero (327032) build clean. **Not hardware tested** — but the `CTRL_SYNC` change is directly observable: if `WRITE FAIL` currently appears on the status line during normal use, it should stop.

---

*Disclosure: written with Claude (Anthropic's Claude Code); the commit carries a `Co-Authored-By` trailer.*
