### PR TITLE
Stop the updater bricking cards, and fix three out of bounds accesses

### DIFF
--- a/src/emulation/iec_bus.h
+++ b/src/emulation/iec_bus.h
@@ -777,7 +777,14 @@ public:
 	// disables it (the drive then simply never drives ATN).
 	static inline void SetAtnOutGPIO(u32 gpio)
 	{
-		atnOutGPIO = gpio;
+		// Range check it here, once, rather than trusting options.txt.
+		// RefreshAtnOut turns this straight into a register address -
+		// ARM_GPIO_GPFSEL0 + (gpio / 10) * 4 - so a typo like 240 in the
+		// config file walks out of the GPIO bank entirely and starts
+		// read-modify-writing whatever peripheral registers happen to follow.
+		// The BCM283x has GPIO 0-53; anything else disables the function,
+		// which is what 0 already means.
+		atnOutGPIO = (gpio <= 53) ? gpio : 0;
 	}
 
 	// CA1 input ATN

--- a/src/emulation/scsi.cpp
+++ b/src/emulation/scsi.cpp
@@ -993,13 +993,30 @@ void scsi_process_ack(scsi_context_t* context)
 					/* accept defect list, just don't do anything about it */
 					if (context->seq == 4)
 					{
-						context->seq = ((context->data_buf[0] << 24) |
+						// The four byte header says how long the list is. That
+						// belongs in data_max - the count of bytes still to
+						// come - not in seq, which is the index the next byte
+						// is stored at. Assigning it to seq meant the byte
+						// after the header was written at data_buf[length],
+						// and with the cap at 512 on a 512 byte buffer that is
+						// one past the end.
+						u32 listBytes = ((context->data_buf[0] << 24) |
 							(context->data_buf[1] << 16) |
 							(context->data_buf[2] << 8) |
 							(context->data_buf[3])) + 4;
-						if (context->seq > 512)
+
+						if (listBytes > sizeof(context->data_buf))
+							listBytes = sizeof(context->data_buf);
+
+						context->data_max = listBytes;
+
+						// An empty list leaves nothing to receive, so finish
+						// here rather than waiting for a byte that is not
+						// coming.
+						if (context->seq >= context->data_max)
 						{
-							context->seq = 512;
+							context->status = SCSI_STATUS_GOOD;
+							context->state = SCSI_STATE_STATUS;
 						}
 					}
 					else

--- a/src/emulation/scsi.cpp
+++ b/src/emulation/scsi.cpp
@@ -993,30 +993,38 @@ void scsi_process_ack(scsi_context_t* context)
 					/* accept defect list, just don't do anything about it */
 					if (context->seq == 4)
 					{
-						// The four byte header says how long the list is. That
-						// belongs in data_max - the count of bytes still to
-						// come - not in seq, which is the index the next byte
-						// is stored at. Assigning it to seq meant the byte
-						// after the header was written at data_buf[length],
-						// and with the cap at 512 on a 512 byte buffer that is
-						// one past the end.
-						u32 listBytes = ((context->data_buf[0] << 24) |
-							(context->data_buf[1] << 16) |
-							(context->data_buf[2] << 8) |
+						// Defect list length is bytes 2-3 of the header; 0-1
+						// are reserved. It also belongs in data_max - the
+						// count of bytes still to come - not in seq, which is
+						// the index the next byte is stored at. Assigning it
+						// to seq meant the byte after the header landed at
+						// data_buf[length], and capped at 512 on a 512 byte
+						// buffer that is one past the end.
+						u32 listBytes = ((context->data_buf[2] << 8) |
 							(context->data_buf[3])) + 4;
 
 						if (listBytes > sizeof(context->data_buf))
-							listBytes = sizeof(context->data_buf);
-
-						context->data_max = listBytes;
-
-						// An empty list leaves nothing to receive, so finish
-						// here rather than waiting for a byte that is not
-						// coming.
-						if (context->seq >= context->data_max)
 						{
-							context->status = SCSI_STATUS_GOOD;
+							// Do not quietly truncate and then report success:
+							// that changes phase while the initiator still has
+							// data to send. Say the field is wrong instead.
+							context->sensekey = SCSI_SENSEKEY_ILLEGALREQUEST;
+							context->asc = SCSI_SASC_INVALIDFIELDINPARAMETERLIST;
+							context->status = SCSI_STATUS_CHECKCONDITION;
 							context->state = SCSI_STATE_STATUS;
+						}
+						else
+						{
+							context->data_max = listBytes;
+
+							// An empty list leaves nothing to receive, so
+							// finish here rather than waiting for a byte that
+							// is not coming.
+							if (context->seq >= context->data_max)
+							{
+								context->status = SCSI_STATUS_GOOD;
+								context->state = SCSI_STATE_STATUS;
+							}
 						}
 					}
 					else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1530,7 +1530,13 @@ void UpdateFirmwareToSD()
 		{
 			f_chdir("\\");
 
-			bool found = f_findfirst(&dir, &filInfo, ".", firmwareName) == FR_OK;
+			// f_findfirst returns FR_OK when there is no match too, leaving
+			// fname empty and the rest of filInfo untouched - so testing the
+			// result alone let a missing kernel.img through and handed an
+			// uninitialised fsize to malloc.
+			bool found = (f_findfirst(&dir, &filInfo, ".", firmwareName) == FR_OK) &&
+				(filInfo.fname[0] != 0);
+			f_closedir(&dir);
 
 			if (found)
 			{
@@ -1623,15 +1629,42 @@ void UpdateFirmwareToSD()
 											written = (wres == FR_OK) && (cres == FR_OK) && (bytes == (u32)filInfo.fsize);
 										}
 
-										if (written && f_unlink(firmwareName) == FR_OK &&
-											f_rename(tempName, firmwareName) == FR_OK)
+										// Keep the old kernel until the new one is in
+										// place. Deleting it first and then renaming
+										// left nothing at all if the rename failed -
+										// and the error path deleted the replacement
+										// too, so a failure there was still an
+										// unbootable card. Moving it aside instead
+										// means the worst case is a machine that
+										// needs kernel.bak renamed back by hand.
+										const char* backupName = "kernel.bak";
+										bool updated = false;
+
+										if (written)
+										{
+											f_unlink(backupName);		// clear any stale backup
+
+											if (f_rename(firmwareName, backupName) == FR_OK)
+											{
+												if (f_rename(tempName, firmwareName) == FR_OK)
+												{
+													f_unlink(backupName);
+													updated = true;
+												}
+												else
+												{
+													// Put the working kernel back.
+													f_rename(backupName, firmwareName);
+												}
+											}
+										}
+
+										if (updated)
 										{
 											DEBUG_LOG("firmware: updated %s\r\n", firmwareName);
 										}
 										else
 										{
-											// Leave whatever is there alone rather than half
-											// replacing it.
 											f_unlink(tempName);
 											DEBUG_LOG("firmware: update failed, keeping the existing kernel\r\n");
 											snprintf(tempBuffer, tempBufferSize, "Firmware update FAILED.\r\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1557,32 +1557,48 @@ void UpdateFirmwareToSD()
 							{
 								if (f_chdir("\\") == FR_OK)
 								{
-									bool same = true;
-									if (FR_OK == f_open(&fp, firmwareName, FA_READ))
+									// Compare sizes before contents. The old loop read fixed 256
+									// byte blocks with the result ignored, which went wrong three
+									// ways: a shorter file on the card hit EOF, returned zero
+									// bytes, never advanced the index and span forever; a size
+									// that is not a multiple of 256 read past the end of the USB
+									// image; and a longer file with the same leading bytes
+									// counted as identical.
+									bool same = false;
+									FILINFO sdInfo;
+									if (f_stat(firmwareName, &sdInfo) == FR_OK &&
+										(u32)sdInfo.fsize == (u32)filInfo.fsize)
 									{
-										char* ptr = mem;
-										char buffer[256];
-										unsigned bufferIndex = 0;
-										unsigned bytesRead;
-										do
+										if (FR_OK == f_open(&fp, firmwareName, FA_READ))
 										{
-											f_read(&fp, buffer, 256, &bytesRead);
-
-											for (unsigned index = 0; index < bytesRead; ++index)
+											char buffer[256];
+											u32 offset = 0;
+											same = true;
+											while (same && offset < (u32)filInfo.fsize)
 											{
-												if (buffer[index] != mem[bufferIndex + index])
+												unsigned want = (u32)filInfo.fsize - offset;
+												if (want > sizeof(buffer))
+													want = sizeof(buffer);
+
+												unsigned bytesRead = 0;
+												if (f_read(&fp, buffer, want, &bytesRead) != FR_OK || bytesRead != want)
 												{
+													// Could not read it all, so we do not know it matches.
 													same = false;
 													break;
 												}
+
+												if (memcmp(buffer, mem + offset, want) != 0)
+													same = false;
+
+												offset += want;
 											}
-											bufferIndex += bytesRead;
-										} while (same && (bufferIndex < (u32)filInfo.fsize));
-										f_close(&fp);
+											f_close(&fp);
+										}
 									}
 
 									screen.Clear(COLOUR_BLACK);
-									if (!same && (FR_OK == f_open(&fp, firmwareName, FA_CREATE_ALWAYS | FA_WRITE)))
+									if (!same)
 									{
 										snprintf(tempBuffer, tempBufferSize, "Updating firmware.\r\n");
 										screen.MeasureText(false, tempBuffer, &widthText, &heightText);
@@ -1590,8 +1606,37 @@ void UpdateFirmwareToSD()
 										ypos = (heightScreen - heightText) >> 1;
 										screen.PrintText(false, xpos, ypos, tempBuffer, COLOUR_WHITE, COLOUR_RED);
 
-										res = f_write(&fp, mem, (u32)filInfo.fsize, &bytes);
-										f_close(&fp);
+										// Write a temporary file and only put it in place once it
+										// is known to be complete. FA_CREATE_ALWAYS on kernel.img
+										// destroyed the working kernel before the replacement
+										// existed, so a full or failing card left the machine with
+										// a truncated image and nothing to boot. The write and the
+										// close were both unchecked as well.
+										const char* tempName = "kernel.new";
+										bool written = false;
+
+										if (FR_OK == f_open(&fp, tempName, FA_CREATE_ALWAYS | FA_WRITE))
+										{
+											bytes = 0;
+											FRESULT wres = f_write(&fp, mem, (u32)filInfo.fsize, &bytes);
+											FRESULT cres = f_close(&fp);
+											written = (wres == FR_OK) && (cres == FR_OK) && (bytes == (u32)filInfo.fsize);
+										}
+
+										if (written && f_unlink(firmwareName) == FR_OK &&
+											f_rename(tempName, firmwareName) == FR_OK)
+										{
+											DEBUG_LOG("firmware: updated %s\r\n", firmwareName);
+										}
+										else
+										{
+											// Leave whatever is there alone rather than half
+											// replacing it.
+											f_unlink(tempName);
+											DEBUG_LOG("firmware: update failed, keeping the existing kernel\r\n");
+											snprintf(tempBuffer, tempBufferSize, "Firmware update FAILED.\r\n");
+											screen.PrintText(false, xpos, ypos, tempBuffer, COLOUR_WHITE, COLOUR_RED);
+										}
 									}
 								}
 							}

--- a/src/ui/filebrowser.cpp
+++ b/src/ui/filebrowser.cpp
@@ -435,9 +435,14 @@ bool FileBrowser::BrowsableList::CheckBrowseNavigation()
 
 		searchLastKeystrokeTime = 0;
 
-		searchPrefix[searchPrefixIndex] = searchChar;
+		// Store only when there is somewhere for the terminator to go. The
+		// character used to be written unconditionally, so on the last slot it
+		// overwrote the NUL while the guard below stopped a new one being
+		// added - leaving an unterminated buffer that PrintText then walked
+		// off the end of.
 		if (searchPrefixIndex < KEYBOARD_SEARCH_BUFFER_SIZE - 1)
 		{
+			searchPrefix[searchPrefixIndex] = searchChar;
 			searchPrefixIndex++;
 			searchPrefix[searchPrefixIndex] = 0;
 			dirty |= 1;

--- a/src/ui/filebrowser.h
+++ b/src/ui/filebrowser.h
@@ -153,8 +153,15 @@ public:
 
 		struct Entry
 		{
+			// Both FILINFOs get cleared, not just caddyIndex. f_readdir fills
+			// them in completely, but the synthetic entries - "..", the device
+			// list - are built by hand and only ever OR AM_DIR into fattrib,
+			// so anything else left on the stack stayed set. A stray AM_RDO
+			// makes an entry render as read only and be treated that way.
 			Entry() : caddyIndex(-1)
 			{
+				memset(&filImage, 0, sizeof(filImage));
+				memset(&filIcon, 0, sizeof(filIcon));
 			}
 			FILINFO filImage;
 			FILINFO filIcon;


### PR DESCRIPTION
The remaining six findings from the scan, after the urgent `CTRL_SYNC` fix in #13.

### The firmware updater could hang, and could brick a card

Two separate problems in the same function.

**The comparison loop.** It read fixed 256-byte blocks and ignored the result:

```c
f_read(&fp, buffer, 256, &bytesRead);   // result discarded
...
bufferIndex += bytesRead;
} while (same && (bufferIndex < (u32)filInfo.fsize));
```

A shorter `kernel.img` on the card hits EOF, returns zero bytes, never advances `bufferIndex`, and **loops forever** — at boot, before anything reaches the screen. A size that isn't a multiple of 256 reads past the end of the image in RAM. And a longer file sharing the same leading bytes counts as identical.

Now: compare sizes first, read only what remains, check every result.

**The write.** `FA_CREATE_ALWAYS` on `kernel.img` truncates the working kernel *before* a single byte of the replacement is written, and the write result, byte count and close result were all ignored. A full or failing card turns a working machine into one with a truncated kernel and nothing to boot.

Now: write `kernel.new`, verify the write and close both succeeded and the length is right, then replace. On any failure the temporary is removed and the existing kernel is left untouched.

### REASSIGN BLOCKS wrote one byte past data_buf

The four-byte header's length was assigned to `seq` — the index the next byte is stored at — rather than to `data_max`, the count still to come. Capped at 512 on a `u8 data_buf[512]`, the byte after the header lands at `data_buf[512]`. An empty list now completes immediately rather than waiting for a byte that isn't coming.

### CMDHDAtnOutGPIO was used unchecked

`RefreshAtnOut` turns it into a register address: `ARM_GPIO_GPFSEL0 + (gpio / 10) * 4`. A typo like `240` in `options.txt` walks straight out of the GPIO bank and starts read-modify-writing whatever peripheral registers follow. Values above the BCM283x's GPIO 53 now disable the function, which is what `0` already means.

### The keyboard search buffer could lose its terminator

The character was stored unconditionally, so on the last slot it overwrote the NUL while the guard below prevented a new one being written — leaving 512 characters with no terminator for `PrintText` to walk off the end of.

### Browser entries are zero-initialised

Only `caddyIndex` was. The synthetic entries — `..` and the device list — are built by hand and only `|= AM_DIR` into `fattrib`, so anything else left on the stack stayed set. A stray `AM_RDO` renders an entry as read-only and gets it treated that way.

### Testing

Pi 3 (362976) and Pi Zero (327072) build clean, `git diff --check` passes. **Not hardware tested.**

The firmware updater in particular I cannot exercise — it needs a USB stick with a different `kernel.img` — and its failure mode is an unbootable card, so it deserves a careful read rather than a merge on my say-so. The rewrite is strictly safer than what it replaces, but "safer" is not "verified".

---

*Disclosure: written with Claude (Anthropic's Claude Code); the commit carries a `Co-Authored-By` trailer.*
