### PR TITLE
Validate the firmware image, and four smaller correctness fixes

### DIFF
--- a/src/emulation/scsi.cpp
+++ b/src/emulation/scsi.cpp
@@ -412,6 +412,25 @@ int ScsiImage::ReadSector(u32 lba, u8* buffer)
 	return 0;
 }
 
+int ScsiImage::ReadSectorPhysical(u32 lba, u8* buffer)
+{
+	accessCounter++;
+	if (!attached)
+		return -1;
+
+	if (lba >= sizeInSectors)
+		return -1;
+
+	UINT bytesRead = 0;
+	u32 t0 = read32(ARM_SYSTIMER_CLO);
+	if (f_lseek(&file, (u64)lba << 9) != FR_OK)
+		return -1;
+	if (f_read(&file, buffer, SECTOR_SIZE, &bytesRead) != FR_OK || bytesRead != SECTOR_SIZE)
+		return -1;
+	NoteStall(t0);
+	return 0;
+}
+
 int ScsiImage::ReadSectorUncached(u32 lba, u8* buffer)
 {
 	accessCounter++;
@@ -1509,25 +1528,48 @@ void scsi_process_ack(scsi_context_t* context)
 						context->asc = SCSI_SASC_WRITEFAULT;
 						context->status = SCSI_STATUS_CHECKCONDITION;
 					}
+					else if (context->cmd_buf[1] & 0x02)		// BYTCHK
+					{
+						// The initiator wants the blocks compared against data
+						// it is about to send. That needs a data-out phase and
+						// a comparison, neither of which is implemented - and
+						// answering GOOD would be claiming to have done a
+						// byte-for-byte check that never happened, which is
+						// the worst possible answer to give a verify.
+						context->sensekey = SCSI_SENSEKEY_ILLEGALREQUEST;
+						context->asc = SCSI_SASC_INVALIDFIELDINCDB;
+						context->status = SCSI_STATUS_CHECKCONDITION;
+					}
 					else
 					{
-						// Read each block. The data goes nowhere - VERIFY
-						// returns no data phase - but a sector that cannot be
-						// read is exactly what the command is asked to find.
+						// Read each block off the card itself.
+						//
+						// Not through the cache: that would verify the cache.
+						// A sector written a moment ago, or read earlier and
+						// still resident, comes back perfectly from a card
+						// that has since been pulled. Flush first as well, or
+						// the media is checked against contents the computer
+						// has been told are on it but are not yet.
+						ScsiImage* image = context->file[(context->target << 3) | context->lun];
 						context->status = SCSI_STATUS_GOOD;
-						for (u32 b = 0; b < (u32)context->blocks; ++b)
-						{
-							u32 saved = context->address;
-							context->address = saved + b;
-							s32 bad = scsi_image_read(context);
-							context->address = saved;
 
-							if (bad)
+						if (image->Sync(true) < 0)
+						{
+							context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
+							context->asc = SCSI_SASC_WRITEFAULT;
+							context->status = SCSI_STATUS_CHECKCONDITION;
+						}
+						else
+						{
+							for (u32 b = 0; b < (u32)context->blocks; ++b)
 							{
-								context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
-								context->asc = SCSI_SASC_UNRECOVEREDREADERROR;
-								context->status = SCSI_STATUS_CHECKCONDITION;
-								break;
+								if (image->ReadSectorPhysical(context->address + b, context->data_buf) != 0)
+								{
+									context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
+									context->asc = SCSI_SASC_UNRECOVEREDREADERROR;
+									context->status = SCSI_STATUS_CHECKCONDITION;
+									break;
+								}
 							}
 						}
 					}

--- a/src/emulation/scsi.cpp
+++ b/src/emulation/scsi.cpp
@@ -1349,6 +1349,20 @@ void scsi_process_ack(scsi_context_t* context)
 					context->lun = (context->cmd_buf[1] >> 5) & 7;
 					context->link = context->cmd_buf[9] & 1;
 					context->data_max = 8;
+
+					// Say there is no medium rather than describing an absent
+					// one as a zero length disk. Every other command checks
+					// this; capacity did not, and eight zero bytes with GOOD
+					// reads as "a disk, empty" instead of "no disk".
+					if (scsi_imagecheck(context))
+					{
+						context->sensekey = SCSI_SENSEKEY_NOTREADY;
+						context->asc = SCSI_SASC_MEDIUMNOTPRESENT;
+						context->status = SCSI_STATUS_CHECKCONDITION;
+						context->state = SCSI_STATE_STATUS;
+						break;
+					}
+
 					j = scsi_getmaxsize(context);
 					if (j == 0)
 					{
@@ -1462,10 +1476,61 @@ void scsi_process_ack(scsi_context_t* context)
 					context->state = SCSI_STATE_STATUS;
 					break;
 				case SCSI_COMMAND_VERIFY:
+					// This used to answer GOOD without looking at anything -
+					// no media check, no range check, no read - so a verify
+					// pronounced missing, out of range or unreadable sectors
+					// healthy, which is worse than not supporting it. Check
+					// what can be checked cheaply and read the blocks back.
 					context->lun = (context->cmd_buf[1] >> 5) & 7;
 					context->link = context->cmd_buf[9] & 1;
-					context->status = SCSI_STATUS_GOOD;
+					context->address = (context->cmd_buf[2] << 24) |
+						(context->cmd_buf[3] << 16) |
+						(context->cmd_buf[4] << 8) | (context->cmd_buf[5]);
+					context->blocks = (context->cmd_buf[7] << 8) | (context->cmd_buf[8]);
 					context->state = SCSI_STATE_STATUS;
+
+					if (scsi_imagecheck(context))
+					{
+						context->sensekey = SCSI_SENSEKEY_NOTREADY;
+						context->asc = SCSI_SASC_MEDIUMNOTPRESENT;
+						context->status = SCSI_STATUS_CHECKCONDITION;
+					}
+					else if (context->blocks &&
+						(context->address >= scsi_getmaxsize(context) ||
+						 context->address + context->blocks > scsi_getmaxsize(context)))
+					{
+						context->sensekey = SCSI_SENSEKEY_ILLEGALREQUEST;
+						context->asc = SCSI_SASC_LOGICALBLOCKADDRESSOUTOFRANGE;
+						context->status = SCSI_STATUS_CHECKCONDITION;
+					}
+					else if (scsi_take_deferred_write_error(context))
+					{
+						context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
+						context->asc = SCSI_SASC_WRITEFAULT;
+						context->status = SCSI_STATUS_CHECKCONDITION;
+					}
+					else
+					{
+						// Read each block. The data goes nowhere - VERIFY
+						// returns no data phase - but a sector that cannot be
+						// read is exactly what the command is asked to find.
+						context->status = SCSI_STATUS_GOOD;
+						for (u32 b = 0; b < (u32)context->blocks; ++b)
+						{
+							u32 saved = context->address;
+							context->address = saved + b;
+							s32 bad = scsi_image_read(context);
+							context->address = saved;
+
+							if (bad)
+							{
+								context->sensekey = SCSI_SENSEKEY_MEDIUMERROR;
+								context->asc = SCSI_SASC_UNRECOVEREDREADERROR;
+								context->status = SCSI_STATUS_CHECKCONDITION;
+								break;
+							}
+						}
+					}
 					break;
 				}
 			}

--- a/src/emulation/scsi.h
+++ b/src/emulation/scsi.h
@@ -61,6 +61,16 @@ public:
 	int ReadSectorUncached(u32 lba, u8* buffer);
 	int WriteSector(u32 lba, const u8* buffer);
 
+	// Read straight off the card, ignoring the cache entirely - not even as a
+	// shortcut, which is what separates this from ReadSectorUncached.
+	//
+	// Only VERIFY wants this. Verifying through the cache verifies the cache:
+	// a sector that was written a moment ago, or read earlier and still held,
+	// comes back fine from a card that has since been removed or has stopped
+	// answering. Flush before calling it, or what is on the card is not what
+	// the computer believes it wrote.
+	int ReadSectorPhysical(u32 lba, u8* buffer);
+
 	// Longest single SD access so far, in microseconds. The bus timeout that
 	// shows up as ?DEVICE NOT PRESENT is a few milliseconds, so this is the
 	// number that says whether the cache is doing its job.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1538,6 +1538,25 @@ void UpdateFirmwareToSD()
 				(filInfo.fname[0] != 0);
 			f_closedir(&dir);
 
+			// Sanity check the size before going anywhere near the working
+			// kernel. Nothing here validated the source at all, so a truncated
+			// or one byte kernel.img on the stick read fine, wrote fine, and
+			// replaced a bootable machine with an unbootable one - the exact
+			// outcome the temporary-file dance was added to prevent. There is
+			// no header to check (a kernel image is raw ARM code from byte
+			// zero), but a real one is a few hundred KB, so a floor well below
+			// any genuine build and a ceiling well above one rejects the
+			// obviously wrong without guessing at content.
+			static const u32 FIRMWARE_MIN_SIZE = 64 * 1024;
+			static const u32 FIRMWARE_MAX_SIZE = 8 * 1024 * 1024;
+
+			if (found && ((u32)filInfo.fsize < FIRMWARE_MIN_SIZE || (u32)filInfo.fsize > FIRMWARE_MAX_SIZE))
+			{
+				DEBUG_LOG("firmware: %s on USB is %u bytes, not a plausible kernel - ignoring\r\n",
+					firmwareName, (u32)filInfo.fsize);
+				found = false;
+			}
+
 			if (found)
 			{
 				char* mem = (char*)malloc((u32)filInfo.fsize);
@@ -1648,7 +1667,15 @@ void UpdateFirmwareToSD()
 											{
 												if (f_rename(tempName, firmwareName) == FR_OK)
 												{
-													f_unlink(backupName);
+													// Keep kernel.bak rather than
+													// deleting it. It costs one
+													// kernel of card space and is
+													// the only way back if the new
+													// image turns out not to boot -
+													// at which point there is no
+													// working machine to fix it
+													// from. The next update
+													// replaces it.
 													updated = true;
 												}
 												else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1547,13 +1547,18 @@ void UpdateFirmwareToSD()
 			// zero), but a real one is a few hundred KB, so a floor well below
 			// any genuine build and a ceiling well above one rejects the
 			// obviously wrong without guessing at content.
-			static const u32 FIRMWARE_MIN_SIZE = 64 * 1024;
-			static const u32 FIRMWARE_MAX_SIZE = 8 * 1024 * 1024;
+			// Compared at FSIZE_t's own width, before any cast. exFAT is
+			// enabled in ffconf.h, so fsize is 64 bit - and casting first
+			// meant a file of 4GiB plus something plausible wrapped straight
+			// into the accepted range, after which only that low prefix was
+			// read and installed as the kernel.
+			static const FSIZE_t FIRMWARE_MIN_SIZE = 64 * 1024;
+			static const FSIZE_t FIRMWARE_MAX_SIZE = 8 * 1024 * 1024;
 
-			if (found && ((u32)filInfo.fsize < FIRMWARE_MIN_SIZE || (u32)filInfo.fsize > FIRMWARE_MAX_SIZE))
+			if (found && (filInfo.fsize < FIRMWARE_MIN_SIZE || filInfo.fsize > FIRMWARE_MAX_SIZE))
 			{
-				DEBUG_LOG("firmware: %s on USB is %u bytes, not a plausible kernel - ignoring\r\n",
-					firmwareName, (u32)filInfo.fsize);
+				DEBUG_LOG("firmware: %s on USB is %llu bytes, not a plausible kernel - ignoring\r\n",
+					firmwareName, (unsigned long long)filInfo.fsize);
 				found = false;
 			}
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -25,6 +25,28 @@
 
 #define INVALID_VALUE	((unsigned) -1)
 
+// Copy an option value into a fixed buffer, terminated.
+//
+// Every one of these was "strncpy(dest, pValue, 255)" into a char[256], which
+// writes no terminator at all when the value is 255 characters or longer -
+// strncpy only copies one if it finds one inside the count. Byte 255 then held
+// whatever was there before, and the result was handed to f_open, strcasecmp
+// and PrintText as if it were a string.
+static void CopyOption(char* dest, unsigned size, const char* value)
+{
+	if (!dest || !size)
+		return;
+
+	if (!value)
+	{
+		dest[0] = 0;
+		return;
+	}
+
+	strncpy(dest, value, size - 1);
+	dest[size - 1] = 0;
+}
+
 char* TextParser::GetToken(bool includeSpace)
 {
 	bool isSpace;
@@ -211,11 +233,11 @@ void Options::Process(char* buffer)
 
 		if ((strcasecmp(pOption, "Font") == 0) || (strcasecmp(pOption, "ChargenFont") == 0))
 		{
-			strncpy(ROMFontName, pValue, 255);
+			CopyOption(ROMFontName, sizeof(ROMFontName), pValue);
 		}
 		else if ((strcasecmp(pOption, "AutoMountImage") == 0))
 		{
-			strncpy(autoMountImageName, pValue, 255);
+			CopyOption(autoMountImageName, sizeof(autoMountImageName), pValue);
 		}
 		ELSE_CHECK_DECIMAL_OPTION(onResetChangeToStartingFolder)
 		ELSE_CHECK_DECIMAL_OPTION(supportUARTInput)
@@ -252,11 +274,11 @@ void Options::Process(char* buffer)
 		ELSE_CHECK_DECIMAL_OPTION(CMDHDButtonExit)
 		else if ((strcasecmp(pOption, "LCDLogoName") == 0))
 		{
-			strncpy(LcdLogoName, pValue, 255);
+			CopyOption(LcdLogoName, sizeof(LcdLogoName), pValue);
 		}
 		else if ((strcasecmp(pOption, "LCDName") == 0))
 		{
-			strncpy(LCDName, pValue, 255);
+			CopyOption(LCDName, sizeof(LCDName), pValue);
 			if (strcasecmp(pValue, "ssd1306_128x64") == 0)
 				i2cLcdModel = LCD_1306_128x64;
 			else if (strcasecmp(pValue, "ssd1306_128x32") == 0)
@@ -266,7 +288,7 @@ void Options::Process(char* buffer)
 		}
 		else if ((strcasecmp(pOption, "CMDHDRomName") == 0) || (strcasecmp(pOption, "ROMCMDHD") == 0))
 		{
-			strncpy(ROMNameCMDHD, pValue, 255);
+			CopyOption(ROMNameCMDHD, sizeof(ROMNameCMDHD), pValue);
 		}
 		ELSE_CHECK_DECIMAL_OPTION(CMDHDDeviceID)
 		ELSE_CHECK_DECIMAL_OPTION(CMDHDCacheMB)

--- a/src/ui/filebrowser.cpp
+++ b/src/ui/filebrowser.cpp
@@ -703,7 +703,18 @@ void FileBrowser::RefreshFolderEntries()
 							for (unsigned index = 0; index < folder.entries.size(); ++index)
 							{
 								FileBrowser::BrowsableList::Entry* entryAtIndex = &folder.entries[index];
-								if (strncasecmp(entry.filIcon.fname, entryAtIndex->filImage.fname, length) == 0)
+
+								// Match the whole stem, not just its first
+								// characters. A prefix compare gave hd.png to
+								// hd-backup.dhd as readily as to hd.dhd, and
+								// which one ended up with it depended on the
+								// order the directory happened to enumerate in.
+								const char* imageExt = strrchr(entryAtIndex->filImage.fname, '.');
+								int imageStem = imageExt ? (int)(imageExt - entryAtIndex->filImage.fname)
+									: (int)strlen(entryAtIndex->filImage.fname);
+
+								if (imageStem == length &&
+									strncasecmp(entry.filIcon.fname, entryAtIndex->filImage.fname, length) == 0)
 									entryAtIndex->filIcon = entry.filIcon;
 							}
 						}

--- a/src/ui/screen.cpp
+++ b/src/ui/screen.cpp
@@ -239,7 +239,9 @@ void Screen::WriteChar(bool petscii, u32 x, u32 y, unsigned char c, RGBA colour)
 		}
 		for (u32 py = 0; py < fontHeight; ++py)
 		{
-			if (y + py > height)
+			// >= , not >. Valid rows are 0..height-1, so y + py == height is
+			// already one scanline past the end of the framebuffer.
+			if (y + py >= height)
 				return;
 
 			unsigned char b = fontBitMap[c * fontHeight + py];

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -36,7 +36,7 @@ endif
 UNDER_TEST = $(SRCDIR)/emulation/scsi.cpp
 
 TEST_SRCS  = main.cpp harness.cpp \
-             test_scsi_cache.cpp \
+             test_scsi_cache.cpp test_scsi_physical_read.cpp \
              $(SHIMS)/ff.cpp $(SHIMS)/fakeclock.cpp $(SHIMS)/debug.cpp
 
 TARGET     = run_tests

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,9 +1,11 @@
 #include "harness.h"
 
 void RunScsiCacheTests();
+void RunScsiPhysicalReadTests();
 
 int main()
 {
 	RunScsiCacheTests();
+	RunScsiPhysicalReadTests();
 	return Harness::Summary();
 }

--- a/tests/test_scsi_physical_read.cpp
+++ b/tests/test_scsi_physical_read.cpp
@@ -1,0 +1,164 @@
+// Tests for ReadSectorPhysical - the read path VERIFY uses.
+//
+// VERIFY exists to find bad media. Reading through the cache verifies the
+// cache: a sector written a moment ago, or read earlier and still resident,
+// comes back perfectly from a card that has since been pulled. So the property
+// under test is not "it returns the right bytes" but "it goes to the card,
+// every time, and notices when the card will not answer".
+
+#include "harness.h"
+#include "shims/fakefs.h"
+#include "shims/fakeclock.h"
+#include "scsi.h"
+
+#include <string.h>
+#include <vector>
+
+namespace
+{
+	const u32 SECTOR = ScsiImage::SECTOR_SIZE;
+	const char* IMAGE = "verify.dhd";
+	const u32 IMAGE_SECTORS = 256;
+
+	void FreshImage(unsigned char fill)
+	{
+		FakeFs::Reset();
+		FakeClock::Reset();
+		FakeFs::CreateFile(IMAGE, IMAGE_SECTORS * SECTOR, fill);
+	}
+
+	std::vector<u8> Pattern(unsigned char v)
+	{
+		return std::vector<u8>(SECTOR, v);
+	}
+}
+
+// The distinguishing case. A sector is written (so the cache holds it, dirty
+// and unflushed) and then read physically - which must return what is on the
+// card, not what the cache is holding. Through the cache these are the same
+// bytes and the test would prove nothing; unflushed, they differ.
+static void PhysicalReadIgnoresDirtyCache()
+{
+	TEST_CASE("a physical read returns the card, not unflushed cache contents");
+	FreshImage(0xC1);
+
+	ScsiImage img;
+	CHECK(img.Attach(IMAGE, false));
+
+	std::vector<u8> buf = Pattern(0xC2);
+	CHECK_EQ(img.WriteSector(4, &buf[0]), 0);		// dirty, not flushed
+
+	std::vector<u8> got(SECTOR, 0);
+	CHECK_EQ(img.ReadSectorPhysical(4, &got[0]), 0);
+	CHECK_MSG(got[0] == 0xC1, "physical read was served from the cache");
+
+	// Through the ordinary path it is the cached value, as it should be.
+	std::vector<u8> cached(SECTOR, 0);
+	CHECK_EQ(img.ReadSector(4, &cached[0]), 0);
+	CHECK_EQ(cached[0], 0xC2);
+
+	// And once flushed, the two agree.
+	CHECK_EQ(img.Sync(true), 0);
+	CHECK_EQ(img.ReadSectorPhysical(4, &got[0]), 0);
+	CHECK_EQ(got[0], 0xC2);
+
+	img.Detach();
+}
+
+// A sector that has been read once sits in the cache. If the card then stops
+// answering, a verify must notice - which it cannot if the cache satisfies the
+// read.
+static void PhysicalReadNoticesADeadCard()
+{
+	TEST_CASE("a physical read fails on a dead card even when cached");
+	FreshImage(0xD1);
+
+	ScsiImage img;
+	CHECK(img.Attach(IMAGE, false));
+
+	// Pull it into the cache the ordinary way.
+	std::vector<u8> got(SECTOR, 0);
+	CHECK_EQ(img.ReadSector(6, &got[0]), 0);
+	CHECK_EQ(got[0], 0xD1);
+
+	// Now the card stops answering.
+	FakeFs::FailReadsAfter(0);
+
+	// The cached path can still satisfy this - that is the cache doing its
+	// job, and is not what VERIFY should be asking.
+	CHECK_EQ(img.ReadSector(6, &got[0]), 0);
+
+	// The physical path must not.
+	CHECK_MSG(img.ReadSectorPhysical(6, &got[0]) != 0,
+		"physical read succeeded against a card that cannot be read");
+
+	FakeFs::FailReadsAfter(-1);
+	img.Detach();
+}
+
+static void PhysicalReadAlwaysTouchesTheCard()
+{
+	TEST_CASE("a physical read goes to the card every time");
+	FreshImage(0xE1);
+
+	ScsiImage img;
+	CHECK(img.Attach(IMAGE, false));
+
+	std::vector<u8> got(SECTOR, 0);
+
+	unsigned before = FakeFs::ReadCallCount();
+	CHECK_EQ(img.ReadSectorPhysical(9, &got[0]), 0);
+	unsigned afterFirst = FakeFs::ReadCallCount();
+	CHECK_MSG(afterFirst > before, "first physical read did not reach the card");
+
+	// A second read of the same sector must go again - no caching, not even
+	// opportunistically.
+	CHECK_EQ(img.ReadSectorPhysical(9, &got[0]), 0);
+	CHECK_MSG(FakeFs::ReadCallCount() > afterFirst,
+		"second physical read was served from somewhere other than the card");
+
+	img.Detach();
+}
+
+static void PhysicalReadRejectsOutOfRange()
+{
+	TEST_CASE("a physical read past the end of the image fails");
+	FreshImage(0xF1);
+
+	ScsiImage img;
+	CHECK(img.Attach(IMAGE, false));
+
+	std::vector<u8> got(SECTOR, 0);
+	CHECK_EQ(img.ReadSectorPhysical(IMAGE_SECTORS - 1, &got[0]), 0);
+
+	// Unlike ReadSector, which zero fills past the end to match VICE, a verify
+	// of a block that is not on the disk is an error rather than a hole.
+	CHECK_MSG(img.ReadSectorPhysical(IMAGE_SECTORS, &got[0]) != 0,
+		"physical read past the end reported success");
+	CHECK_MSG(img.ReadSectorPhysical(IMAGE_SECTORS + 1000, &got[0]) != 0,
+		"physical read well past the end reported success");
+
+	img.Detach();
+}
+
+static void PhysicalReadOnADetachedImageFails()
+{
+	TEST_CASE("a physical read on a detached image fails");
+	FreshImage(0x01);
+
+	ScsiImage img;
+	std::vector<u8> got(SECTOR, 0);
+	CHECK_MSG(img.ReadSectorPhysical(0, &got[0]) != 0,
+		"physical read succeeded with nothing attached");
+}
+
+// ---------------------------------------------------------------------------
+
+void RunScsiPhysicalReadTests()
+{
+	PhysicalReadIgnoresDirtyCache();
+	PhysicalReadNoticesADeadCard();
+	PhysicalReadAlwaysTouchesTheCard();
+	PhysicalReadRejectsOutOfRange();
+	PhysicalReadOnADetachedImageFails();
+}


### PR DESCRIPTION
Six findings from a fresh scan of `main`.

### The firmware updater never looked at what it was installing

Size, plausibility, contents — none of it. A truncated or one-byte `kernel.img` on the USB stick reads fine, writes fine, passes every check the temporary-file dance makes, replaces the working kernel, and then has its backup deleted.

That is exactly the outcome the temporary-file work in #14 was meant to prevent. It made the *copy* safe and left the *source* unexamined — I validated that the bytes arrived intact without ever asking whether they were a kernel.

There is no header to check (a kernel image is raw ARM code from byte zero), so this rejects anything below 64KB or above 8MB before the existing kernel is touched — a floor well under any genuine build and a ceiling well over one.

`kernel.bak` also now **stays** rather than being deleted on success. It costs one kernel of card space and is the only way back if the new image doesn't boot — at which point there is no working machine to fix it from.

### String options could be left unterminated

All five were `strncpy(dest, pValue, 255)` into a `char[256]`. `strncpy` writes a terminator only if it finds one inside the count, so a value of 255 characters or more left byte 255 holding whatever was there before — and the result went to `f_open`, `strcasecmp` and `PrintText` as a string. Affects `Font`, `AutoMountImage`, `LCDLogoName`, `LCDName`, `CMDHDRomName`.

Now one helper that terminates and takes the size from `sizeof`.

### VERIFY answered GOOD without looking at anything

No media check, no range check, no read. It pronounced missing, out-of-range and unreadable sectors healthy — worse than not implementing the command, because a verify pass is specifically what you run when you suspect damage.

Now reports `NOT READY` with no image, out-of-range as such, and reads each block so an unreadable one surfaces as `MEDIUM ERROR`.

### READ CAPACITY described an absent disk as an empty one

Every other command checks for media; this returned eight zero bytes and `GOOD`, which reads as "a disk, zero blocks" rather than "no disk".

### Text clipped at the bottom wrote one scanline past the framebuffer

`if (y + py > height)` — valid rows stop at `height - 1`.

### PNG icons matched on a prefix

`hd.png` attached itself to `hd-backup.dhd` as readily as to `hd.dhd`, with directory enumeration order deciding which won. Stems must now be the same length.

### Testing

Pi 3 (363376) and Pi Zero (327408) build clean; `git diff --check` passes. **Not hardware tested.**

The firmware updater is the one that most deserves a careful read — I have no way to exercise it, and this is the second round of fixes to it.

---

*Disclosure: written with Claude (Anthropic's Claude Code); the commit carries a `Co-Authored-By` trailer.*
