### PR TITLE
Add host tests for the disk cache, and run them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  # The host tests. These are the ones that can actually fail on logic rather
+  # than on whether something compiles, so they run first and with the
+  # sanitizers on - Linux has libasan, unlike MinGW.
+  tests:
+    name: Host tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and run
+        run: make -C tests SANITIZE=1
+
+  # Both targets, because they have broken independently before: the Pi Zero
+  # build has its own conditional code and is not exercised by day to day work
+  # on a Pi 3.
+  firmware:
+    name: Build RASPPI=${{ matrix.rasppi }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rasppi: [0, 2, 3]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install the ARM toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi \
+                                  libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+      - name: Build
+        run: make RASPPI=${{ matrix.rasppi }}
+      - name: Check a kernel came out
+        run: test -s target/kernel.img

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 # Build output
 target/
 
+# Host test binary
+tests/run_tests
+tests/run_tests.exe
+
 # ...but the Raspberry Pi firmware kept for building SD cards is not a build
 # artifact, despite matching the patterns above.
 !firmware/**/*.elf

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,58 @@
+# Host build of the emulator's pure logic, with the hardware stubbed out.
+#
+# The emulator sources are compiled UNMODIFIED. The shims work by sitting
+# earlier on the include path than the real ff.h and rpihardware.h, so no
+# production file needs a test-only #ifdef in it. Keep it that way: the moment
+# a header here has to change for the tests, the seam has moved.
+#
+#   make            build and run
+#   make build      build only
+#   make clean
+
+CXX      ?= g++
+
+SRCDIR    = ../src
+SHIMS     = shims
+
+# shims first, so ff.h and rpihardware.h resolve here rather than in src.
+INCLUDE   = -I$(SHIMS) -I. -I$(SRCDIR) -I$(SRCDIR)/emulation -I$(SRCDIR)/fatfs -I../uspi/include
+
+CXXFLAGS  = -g -O1 -Wall -Wextra -Wno-unused-parameter -std=c++14 $(INCLUDE)
+
+# Address and UB sanitizers catch the class of thing that keeps turning up in
+# this codebase - the one byte past data_buf, the sixteenth byte in a fifteen
+# byte buffer - so run with them wherever they exist.
+#
+# Off by default because MinGW on Windows ships no libasan or libubsan and the
+# link simply fails. On Linux and macOS, and in CI, use:
+#
+#   make SANITIZE=1
+SANITIZE ?= 0
+ifeq ($(SANITIZE),1)
+CXXFLAGS += -fsanitize=address,undefined -fno-omit-frame-pointer
+endif
+
+# Code under test - real emulator sources, no copies.
+UNDER_TEST = $(SRCDIR)/emulation/scsi.cpp
+
+TEST_SRCS  = main.cpp harness.cpp \
+             test_scsi_cache.cpp \
+             $(SHIMS)/ff.cpp $(SHIMS)/fakeclock.cpp $(SHIMS)/debug.cpp
+
+TARGET     = run_tests
+
+.PHONY: all build run clean
+
+all: run
+
+build: $(TARGET)
+
+$(TARGET): $(TEST_SRCS) $(UNDER_TEST)
+	@echo "  HOSTCXX $(TARGET)"
+	$(CXX) $(CXXFLAGS) -o $(TARGET) $(TEST_SRCS) $(UNDER_TEST)
+
+run: $(TARGET)
+	@./$(TARGET)
+
+clean:
+	$(RM) $(TARGET) $(TARGET).exe

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,6 +66,12 @@ FAIL  a short write is a failure, and the data survives it
 That `got 171` is the original fill byte still sitting on the card: the tail of
 the sector never landed. Restore with `git checkout -- src/emulation/scsi.cpp`.
 
+Do this for a case you have just written, before trusting it. The eviction test
+here passed its first review while asserting nothing at all — it recovered the
+card, flushed, and never looked at whether the data had survived, so clearing a
+failed victim's dirty mask left all 135 checks green. A case that cannot fail is
+worse than no case, because it reads as coverage.
+
 ## Worth knowing
 
 These tests replace the hardware layer, so they **cannot** catch a bug in it.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,93 @@
+# Host tests
+
+The emulation modules are pure logic — they reach hardware through a handful of
+free functions and nothing else. That makes them testable on a desktop compiler
+without an emulator, a Pi, or a serial cable.
+
+```
+cd tests
+make                    build and run
+make SANITIZE=1         with ASan and UBSan (Linux/macOS; MinGW has no libasan)
+make clean
+```
+
+## How it works
+
+The emulator sources are compiled **unmodified**. No `#ifdef TEST`, no
+dependency injection, no test-only constructors. The substitution happens on
+the include path:
+
+```
+-Ishims -I../src -I../src/emulation ...
+```
+
+`shims/` sits first, so `ff.h`, `rpihardware.h`, `debug.h` and `integer.h`
+resolve there instead of in `src/`. The code under test cannot tell.
+
+That property is worth defending. **If a header in `src/` ever has to change to
+make a test work, the seam has moved and the design is drifting** — fix the
+seam rather than the test.
+
+| Shim | Stands in for | Why |
+|---|---|---|
+| `ff.h` / `ff.cpp` | FatFS | In-memory files, and every call can be made to fail. Short writes, hard errors, failing sync — the cases that matter are the ones a real card only does when it is dying. |
+| `rpihardware.h` | `read32` / `write32` | Serves a fake clock, so a flush budget measured in microseconds can be tested without sleeping. |
+| `fakeclock.*` | the system timer | Tests advance it by hand; the filesystem shim charges it per access, so an SD access can be made to "take" 35 ms. |
+| `debug.h` | `DEBUG_LOG` | Quiet by default, switchable when a case is misbehaving. |
+| `integer.h` | FatFS's | The real one takes an `#ifdef _WIN32 -> #include <windows.h>` branch that collides with uspi's `boolean`. |
+
+## What is covered
+
+`test_scsi_cache.cpp` — the write-back disk cache. Every case corresponds to a
+bug that reached `main` and was found by reading rather than by running:
+
+- a flushed write actually reaches the card, and a clean cache does no I/O
+- a short write is a failure, and the data survives it
+- a hard write failure keeps the data for a retry
+- an uncached read of an unwritten sector comes from the card, not from
+  uninitialised cache RAM
+- a budgeted flush stops near its deadline, and leaves the rest dirty
+- an unbudgeted flush finishes and marks the cache clean
+- eviction does not discard what it could not write
+- detach on a dead card reports rather than pretending
+
+## Check that a test can fail
+
+A suite that has only ever been green is not evidence of anything. Break
+something on purpose and confirm it goes red — for instance, drop the
+`written != run * SECTOR_SIZE` condition in `FlushChunk` and re-run:
+
+```
+FAIL  a short write is a failure, and the data survives it
+        OnCard(5, SECTOR - 1) == 0x22
+        got 171, expected 34
+```
+
+That `got 171` is the original fill byte still sitting on the card: the tail of
+the sector never landed. Restore with `git checkout -- src/emulation/scsi.cpp`.
+
+## Worth knowing
+
+These tests replace the hardware layer, so they **cannot** catch a bug in it.
+The `disk_ioctl` stub that returned `RES_PARERR` for `CTRL_SYNC` — which made
+every `f_sync` fail on real hardware, and every successful flush report itself
+as a lost write — would pass all of this without complaint, because the fake
+filesystem's `f_sync` returns `FR_OK`.
+
+Tests raise the floor. They do not remove the need to check what a stubbed
+layer actually does on the real thing.
+
+## Adding more
+
+The obvious next ones, in order of value:
+
+1. **The SCSI command state machine.** Already a pure function of
+   `(context, byte in) -> (byte out, state)`. Feed it command bytes, assert the
+   phase transitions and the sense data. Would have caught `REQUEST SENSE`
+   never sending its payload, the unreachable medium-not-present branch, and
+   the `REASSIGN BLOCKS` write past `data_buf`.
+2. **The 65C02 core**, against Klaus Dormann's 6502 functional test suite —
+   one test, enormous coverage.
+3. **Register-level tests** for the 6522, 8255A and RTC. Write a register, read
+   it back, assert you get what you wrote. That is exactly the RTC register F
+   bit mismatch.

--- a/tests/harness.cpp
+++ b/tests/harness.cpp
@@ -1,0 +1,31 @@
+#include "harness.h"
+
+namespace Harness
+{
+	int checks = 0;
+	int failures = 0;
+	const char* currentCase = "(none)";
+
+	void BeginCase(const char* name)
+	{
+		currentCase = name;
+	}
+
+	void Fail(const char* file, int line, const char* expr, const char* detail)
+	{
+		++failures;
+		fprintf(stderr, "FAIL  %s\n        %s:%d\n        %s\n",
+			currentCase, file, line, expr);
+		if (detail)
+			fprintf(stderr, "        %s\n", detail);
+	}
+
+	int Summary()
+	{
+		if (failures)
+			fprintf(stderr, "\n%d of %d checks failed\n", failures, checks);
+		else
+			fprintf(stderr, "all %d checks passed\n", checks);
+		return failures ? 1 : 0;
+	}
+}

--- a/tests/harness.h
+++ b/tests/harness.h
@@ -1,0 +1,51 @@
+// A test harness small enough not to be a dependency.
+//
+// No framework: this project cross compiles for bare metal and pulling gtest
+// in for the host build would be more machinery than the tests are worth. A
+// case is a function, CHECK reports and keeps going so one failure does not
+// hide the next, and main returns non-zero if anything failed - which is all
+// CI needs.
+
+#ifndef TESTS_HARNESS_H
+#define TESTS_HARNESS_H
+
+#include <stdio.h>
+#include <string.h>
+
+namespace Harness
+{
+	extern int checks;
+	extern int failures;
+	extern const char* currentCase;
+
+	void BeginCase(const char* name);
+	void Fail(const char* file, int line, const char* expr, const char* detail);
+	int  Summary();
+}
+
+#define CHECK(expr) \
+	do { \
+		++Harness::checks; \
+		if (!(expr)) Harness::Fail(__FILE__, __LINE__, #expr, 0); \
+	} while (0)
+
+#define CHECK_MSG(expr, msg) \
+	do { \
+		++Harness::checks; \
+		if (!(expr)) Harness::Fail(__FILE__, __LINE__, #expr, msg); \
+	} while (0)
+
+#define CHECK_EQ(a, b) \
+	do { \
+		++Harness::checks; \
+		long long va = (long long)(a), vb = (long long)(b); \
+		if (va != vb) { \
+			char buf[160]; \
+			snprintf(buf, sizeof(buf), "got %lld, expected %lld", va, vb); \
+			Harness::Fail(__FILE__, __LINE__, #a " == " #b, buf); \
+		} \
+	} while (0)
+
+#define TEST_CASE(name) Harness::BeginCase(name)
+
+#endif

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,9 @@
+#include "harness.h"
+
+void RunScsiCacheTests();
+
+int main()
+{
+	RunScsiCacheTests();
+	return Harness::Summary();
+}

--- a/tests/shims/debug.cpp
+++ b/tests/shims/debug.cpp
@@ -1,0 +1,8 @@
+#include "debug.h"
+
+namespace TestLog
+{
+	// Off by default: a passing run should be quiet. Turn it on in a case you
+	// are debugging, or from main while chasing something down.
+	bool enabled = false;
+}

--- a/tests/shims/debug.h
+++ b/tests/shims/debug.h
@@ -1,0 +1,20 @@
+// DEBUG_LOG for the host tests.
+//
+// The real one expands to nothing under NDEBUG, which makes "if (x)
+// DEBUG_LOG(...)" an empty statement and draws -Wempty-body. More usefully, a
+// test can turn the output on when it is trying to work out why a case failed.
+
+#ifndef TESTS_SHIM_DEBUG_H
+#define TESTS_SHIM_DEBUG_H
+
+#include <stdio.h>
+
+namespace TestLog
+{
+	extern bool enabled;
+}
+
+#define DEBUG_LOG(...) \
+	do { if (TestLog::enabled) fprintf(stderr, __VA_ARGS__); } while (0)
+
+#endif

--- a/tests/shims/fakeclock.cpp
+++ b/tests/shims/fakeclock.cpp
@@ -1,0 +1,18 @@
+#include "fakeclock.h"
+
+namespace FakeClock
+{
+	unsigned int micros = 0;
+	unsigned int microsPerAccess = 0;
+
+	void Reset()
+	{
+		micros = 0;
+		microsPerAccess = 0;
+	}
+
+	void Advance(unsigned int us)
+	{
+		micros += us;
+	}
+}

--- a/tests/shims/fakeclock.h
+++ b/tests/shims/fakeclock.h
@@ -1,0 +1,25 @@
+// The fake microsecond clock, shared by the hardware shim (which serves it to
+// the code under test through read32) and the filesystem shim (which advances
+// it, so an SD access appears to take time).
+//
+// Kept separate from both so neither has to include the other.
+
+#ifndef TESTS_FAKECLOCK_H
+#define TESTS_FAKECLOCK_H
+
+namespace FakeClock
+{
+	// Microseconds since "boot". Tests move this directly, and the filesystem
+	// shim moves it on every access.
+	extern unsigned int micros;
+
+	// How long each SD access appears to take. The measured worst case on real
+	// hardware is about 35000; tests that care about the flush budget set this
+	// and then assert how much work fitted inside it.
+	extern unsigned int microsPerAccess;
+
+	void Reset();
+	void Advance(unsigned int us);
+}
+
+#endif

--- a/tests/shims/fakefs.h
+++ b/tests/shims/fakefs.h
@@ -1,0 +1,49 @@
+// Test side control over the fake filesystem in ff.cpp.
+//
+// The emulator only ever sees ff.h; this is how a test sets a card up, breaks
+// it, and then inspects what actually landed on it.
+
+#ifndef TESTS_FAKEFS_H
+#define TESTS_FAKEFS_H
+
+#include <stddef.h>
+#include <vector>
+#include <string>
+
+namespace FakeFs
+{
+	// Forget every file and clear all injected faults. Call at the top of each
+	// test - the fake filesystem is global, like the real one.
+	void Reset();
+
+	// Create a file of `size` bytes, filled with `fill`.
+	void CreateFile(const std::string& name, size_t size, unsigned char fill = 0);
+
+	// What the "card" holds right now. This is the ground truth a test asserts
+	// against - not what the cache thinks it wrote.
+	const std::vector<unsigned char>& Contents(const std::string& name);
+
+	bool Exists(const std::string& name);
+
+	// ---- fault injection -------------------------------------------------
+	//
+	// Counts are "let this many succeed, then start failing". -1 disables.
+
+	// Return FR_DISK_ERR from f_write.
+	void FailWritesAfter(int successes);
+
+	// Return FR_OK from f_write but report fewer bytes than asked - how a full
+	// card behaves, and the case that used to be taken for success.
+	void ShortWritesAfter(int successes, unsigned bytesToActuallyWrite = 0);
+
+	void FailReadsAfter(int successes);
+	void FailSync(bool fail);
+	void FailLseek(bool fail);
+
+	// Counters, for asserting that a flush did or did not go to the card.
+	unsigned WriteCallCount();
+	unsigned ReadCallCount();
+	unsigned SyncCallCount();
+}
+
+#endif

--- a/tests/shims/ff.cpp
+++ b/tests/shims/ff.cpp
@@ -1,0 +1,227 @@
+// In-memory FatFS stand-in. See ff.h and fakefs.h.
+
+#include "ff.h"
+#include "fakefs.h"
+#include "fakeclock.h"
+
+#include <map>
+#include <vector>
+#include <string>
+#include <string.h>
+
+namespace
+{
+	struct File
+	{
+		std::string name;
+		std::vector<unsigned char> data;
+		bool open;
+	};
+
+	std::vector<File> g_files;
+	std::map<std::string, int> g_byName;
+
+	int g_failWritesAfter  = -1;
+	int g_shortWritesAfter = -1;
+	unsigned g_shortWriteBytes = 0;
+	int g_failReadsAfter   = -1;
+	bool g_failSync        = false;
+	bool g_failLseek       = false;
+
+	unsigned g_writes = 0;
+	unsigned g_reads  = 0;
+	unsigned g_syncs  = 0;
+
+	File* Lookup(FIL* fp)
+	{
+		if (!fp || fp->id < 0 || (size_t)fp->id >= g_files.size())
+			return 0;
+		return &g_files[fp->id];
+	}
+
+	// "have this many already gone through?" - shared by the fault switches.
+	bool Triggered(int after, unsigned soFar)
+	{
+		return after >= 0 && soFar > (unsigned)after;
+	}
+}
+
+namespace FakeFs
+{
+	void Reset()
+	{
+		g_files.clear();
+		g_byName.clear();
+		g_failWritesAfter = -1;
+		g_shortWritesAfter = -1;
+		g_shortWriteBytes = 0;
+		g_failReadsAfter = -1;
+		g_failSync = false;
+		g_failLseek = false;
+		g_writes = g_reads = g_syncs = 0;
+	}
+
+	void CreateFile(const std::string& name, size_t size, unsigned char fill)
+	{
+		File f;
+		f.name = name;
+		f.data.assign(size, fill);
+		f.open = false;
+		g_byName[name] = (int)g_files.size();
+		g_files.push_back(f);
+	}
+
+	const std::vector<unsigned char>& Contents(const std::string& name)
+	{
+		static std::vector<unsigned char> empty;
+		std::map<std::string, int>::iterator it = g_byName.find(name);
+		if (it == g_byName.end())
+			return empty;
+		return g_files[it->second].data;
+	}
+
+	bool Exists(const std::string& name)
+	{
+		return g_byName.find(name) != g_byName.end();
+	}
+
+	void FailWritesAfter(int successes)   { g_failWritesAfter = successes; }
+	void FailReadsAfter(int successes)    { g_failReadsAfter = successes; }
+	void FailSync(bool fail)              { g_failSync = fail; }
+	void FailLseek(bool fail)             { g_failLseek = fail; }
+
+	void ShortWritesAfter(int successes, unsigned bytesToActuallyWrite)
+	{
+		g_shortWritesAfter = successes;
+		g_shortWriteBytes = bytesToActuallyWrite;
+	}
+
+	unsigned WriteCallCount() { return g_writes; }
+	unsigned ReadCallCount()  { return g_reads; }
+	unsigned SyncCallCount()  { return g_syncs; }
+}
+
+extern "C"
+{
+
+FRESULT f_open(FIL* fp, const char* path, BYTE mode)
+{
+	if (!fp || !path)
+		return FR_INT_ERR;
+
+	std::string name(path);
+	std::map<std::string, int>::iterator it = g_byName.find(name);
+
+	if (it == g_byName.end())
+	{
+		if (!(mode & FA_CREATE_ALWAYS))
+			return FR_NO_FILE;
+		FakeFs::CreateFile(name, 0);
+		it = g_byName.find(name);
+	}
+	else if (mode & FA_CREATE_ALWAYS)
+	{
+		g_files[it->second].data.clear();
+	}
+
+	fp->id = it->second;
+	fp->fptr = 0;
+	g_files[fp->id].open = true;
+	return FR_OK;
+}
+
+FRESULT f_close(FIL* fp)
+{
+	File* f = Lookup(fp);
+	if (!f)
+		return FR_INVALID_OBJECT;
+	f->open = false;
+	fp->id = -1;
+	return FR_OK;
+}
+
+FRESULT f_lseek(FIL* fp, FSIZE_t ofs)
+{
+	File* f = Lookup(fp);
+	if (!f)
+		return FR_INVALID_OBJECT;
+	if (g_failLseek)
+		return FR_DISK_ERR;
+	fp->fptr = ofs;
+	return FR_OK;
+}
+
+FRESULT f_read(FIL* fp, void* buff, UINT btr, UINT* br)
+{
+	File* f = Lookup(fp);
+	if (br) *br = 0;
+	if (!f)
+		return FR_INVALID_OBJECT;
+
+	++g_reads;
+	FakeClock::Advance(FakeClock::microsPerAccess);
+	if (Triggered(g_failReadsAfter, g_reads))
+		return FR_DISK_ERR;
+
+	// Reads past the end return what is there, like the real thing.
+	UINT avail = 0;
+	if (fp->fptr < f->data.size())
+		avail = (UINT)(f->data.size() - fp->fptr);
+	UINT n = btr < avail ? btr : avail;
+
+	if (n)
+		memcpy(buff, &f->data[(size_t)fp->fptr], n);
+	fp->fptr += n;
+	if (br) *br = n;
+	return FR_OK;
+}
+
+FRESULT f_write(FIL* fp, const void* buff, UINT btw, UINT* bw)
+{
+	File* f = Lookup(fp);
+	if (bw) *bw = 0;
+	if (!f)
+		return FR_INVALID_OBJECT;
+
+	++g_writes;
+	FakeClock::Advance(FakeClock::microsPerAccess);
+
+	if (Triggered(g_failWritesAfter, g_writes))
+		return FR_DISK_ERR;
+
+	UINT n = btw;
+	bool shortWrite = Triggered(g_shortWritesAfter, g_writes);
+	if (shortWrite)
+	{
+		// A full card reports success having written less than asked.
+		n = g_shortWriteBytes;
+		if (n > btw) n = btw;
+	}
+
+	if (f->data.size() < fp->fptr + n)
+		f->data.resize((size_t)(fp->fptr + n), 0);
+	if (n)
+		memcpy(&f->data[(size_t)fp->fptr], buff, n);
+
+	fp->fptr += n;
+	if (bw) *bw = n;
+	return FR_OK;
+}
+
+FRESULT f_sync(FIL* fp)
+{
+	File* f = Lookup(fp);
+	if (!f)
+		return FR_INVALID_OBJECT;
+	++g_syncs;
+	FakeClock::Advance(FakeClock::microsPerAccess);
+	return g_failSync ? FR_DISK_ERR : FR_OK;
+}
+
+FSIZE_t f_size_impl(FIL* fp)
+{
+	File* f = Lookup(fp);
+	return f ? (FSIZE_t)f->data.size() : 0;
+}
+
+} // extern "C"

--- a/tests/shims/ff.h
+++ b/tests/shims/ff.h
@@ -1,0 +1,63 @@
+// Host side stand-in for FatFS, for the tests.
+//
+// Only the surface src/emulation/scsi.cpp actually uses: seven functions, a
+// handful of constants and FIL. Files live in memory, and every call can be
+// made to fail on demand - which is the point, because the interesting
+// behaviour in the disk cache is what it does when the card does not take the
+// data.
+//
+// This header shadows src/fatfs/ff.h by being earlier on the include path. The
+// emulator source is compiled unmodified against it.
+
+#ifndef TESTS_SHIM_FF_H
+#define TESTS_SHIM_FF_H
+
+#include <stddef.h>
+#include "integer.h"		// the real FatFS one - BYTE, UINT and friends
+
+typedef unsigned long long FSIZE_t;
+
+typedef enum {
+	FR_OK = 0,
+	FR_DISK_ERR,
+	FR_INT_ERR,
+	FR_NOT_READY,
+	FR_NO_FILE,
+	FR_DENIED,
+	FR_EXIST,
+	FR_INVALID_OBJECT,
+	FR_WRITE_PROTECTED,
+	FR_TIMEOUT
+} FRESULT;
+
+#define FA_READ				0x01
+#define FA_WRITE			0x02
+#define FA_CREATE_ALWAYS	0x08
+
+// A FIL is just a handle into the fake file table plus a position.
+typedef struct {
+	int   id;			// index into the table, -1 when closed
+	FSIZE_t fptr;		// current offset
+} FIL;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+FRESULT f_open  (FIL* fp, const char* path, BYTE mode);
+FRESULT f_close (FIL* fp);
+FRESULT f_read  (FIL* fp, void* buff, UINT btr, UINT* br);
+FRESULT f_write (FIL* fp, const void* buff, UINT btw, UINT* bw);
+FRESULT f_lseek (FIL* fp, FSIZE_t ofs);
+FRESULT f_sync  (FIL* fp);
+
+FSIZE_t f_size_impl(FIL* fp);
+
+#ifdef __cplusplus
+}
+#endif
+
+// Real FatFS defines this as a macro over the FIL's own size field.
+#define f_size(fp) f_size_impl(fp)
+
+#endif

--- a/tests/shims/integer.h
+++ b/tests/shims/integer.h
@@ -1,0 +1,27 @@
+// FatFS integer types, embedded flavour, for the host tests.
+//
+// The real src/fatfs/integer.h takes an "#ifdef _WIN32 -> #include <windows.h>"
+// branch meant for FatFS's own development environment. Compiling the emulator
+// on a Windows host trips that, and windows.h then collides with uspi's
+// `boolean`. This is the embedded branch of that file with no such branch in
+// it, and nothing else.
+
+#ifndef _FF_INTEGER
+#define _FF_INTEGER
+
+typedef int				INT;
+typedef unsigned int	UINT;
+
+typedef signed char		CHAR;
+typedef unsigned char	BYTE;
+
+typedef short			SHORT;
+typedef unsigned short	WORD;
+typedef unsigned short	WCHAR;
+
+typedef long			LONG;
+typedef unsigned long	DWORD;
+
+typedef unsigned long long QWORD;
+
+#endif

--- a/tests/shims/rpihardware.h
+++ b/tests/shims/rpihardware.h
@@ -1,0 +1,32 @@
+// Host side stand-in for the Pi's MMIO accessors.
+//
+// The disk cache reaches hardware through exactly two things: read32 and the
+// ARM_SYSTIMER_CLO address. Faking them lets a test drive the clock by hand,
+// which is the only way to test a flush budget expressed in microseconds
+// without sleeping - and sleeping in a test is both slow and flaky.
+//
+// Shadows src/rpi/rpihardware.h by being earlier on the include path. The
+// emulator source is compiled unmodified against it.
+
+#ifndef TESTS_SHIM_RPIHARDWARE_H
+#define TESTS_SHIM_RPIHARDWARE_H
+
+#include "fakeclock.h"
+
+// The value only has to be distinguishable, not real.
+#define ARM_SYSTIMER_CLO	0x3F003004u
+
+static inline unsigned int read32(unsigned int nAddress)
+{
+	if (nAddress == ARM_SYSTIMER_CLO)
+		return FakeClock::micros;
+	return 0;
+}
+
+static inline void write32(unsigned int nAddress, unsigned int nValue)
+{
+	(void)nAddress;
+	(void)nValue;
+}
+
+#endif

--- a/tests/test_scsi_cache.cpp
+++ b/tests/test_scsi_cache.cpp
@@ -236,9 +236,19 @@ static void EvictionDoesNotDiscardUnwritableData()
 
 	std::vector<u8> buf = Pattern(0x77);
 
+	// Every sector whose write was ACKNOWLEDGED. That is the promise being
+	// tested: the drive told the computer these landed, so they must end up on
+	// the card - whatever happens to the cache in between. Writes that
+	// honestly reported failure carry no such promise and are not collected.
+	std::vector<u32> acknowledged;
+
 	// Fill the cache with dirty chunks.
 	for (u32 c = 0; c < 16; ++c)
-		CHECK_EQ(img.WriteSector(c * PER_CHUNK, &buf[0]), 0);
+	{
+		u32 lba = c * PER_CHUNK;
+		CHECK_EQ(img.WriteSector(lba, &buf[0]), 0);
+		acknowledged.push_back(lba);
+	}
 
 	// Now break the card and keep writing, forcing evictions that cannot
 	// succeed. Some of these will fail, which is correct - what must not
@@ -247,14 +257,29 @@ static void EvictionDoesNotDiscardUnwritableData()
 	int reported = 0;
 	for (u32 c = 16; c < 64; ++c)
 	{
-		if (img.WriteSector(c * PER_CHUNK, &buf[0]) != 0)
+		u32 lba = c * PER_CHUNK;
+		if (img.WriteSector(lba, &buf[0]) != 0)
 			++reported;
+		else
+			acknowledged.push_back(lba);
 	}
 	CHECK_MSG(reported > 0, "writes against a dead card all claimed to succeed");
 
 	// Recover the card. Everything still held dirty must now land.
 	FakeFs::FailWritesAfter(-1);
 	ScsiImage::FlushAll();
+
+	// The assertion that gives this test its teeth. Without it the case passes
+	// even when a failed eviction clears the victim's dirty bits and drops the
+	// data - which is exactly the bug it is named after.
+	u32 lost = 0;
+	for (size_t i = 0; i < acknowledged.size(); ++i)
+	{
+		if (OnCard(acknowledged[i]) != 0x77 || OnCard(acknowledged[i], SECTOR - 1) != 0x77)
+			++lost;
+	}
+	CHECK_EQ(lost, 0);
+	CHECK_MSG(acknowledged.size() >= 16, "no writes were acknowledged, so nothing was proved");
 
 	img.Detach();
 }

--- a/tests/test_scsi_cache.cpp
+++ b/tests/test_scsi_cache.cpp
@@ -1,0 +1,297 @@
+// Tests for ScsiImage's write-back cache.
+//
+// Every case here corresponds to a bug that reached main and was found by
+// reading rather than by running. The point is that they stay found.
+
+#include "harness.h"
+#include "shims/fakefs.h"
+#include "shims/fakeclock.h"
+#include "scsi.h"
+
+#include <string.h>
+#include <vector>
+
+namespace
+{
+	const u32 SECTOR = ScsiImage::SECTOR_SIZE;					// 512
+	const u32 PER_CHUNK = ScsiImage::SECTORS_PER_CHUNK;			// 8
+	const char* IMAGE = "test.dhd";
+
+	// Enough sectors to spill a 16 slot cache several times over.
+	const u32 IMAGE_SECTORS = 1024;
+
+	void FreshImage(unsigned char fill = 0xAB)
+	{
+		FakeFs::Reset();
+		FakeClock::Reset();
+		FakeFs::CreateFile(IMAGE, IMAGE_SECTORS * SECTOR, fill);
+	}
+
+	std::vector<u8> Pattern(unsigned char v)
+	{
+		return std::vector<u8>(SECTOR, v);
+	}
+
+	// What is actually on the card, as opposed to what the cache believes.
+	unsigned char OnCard(u32 lba, u32 offsetInSector = 0)
+	{
+		// Name held in a local: passing the literal would build a temporary
+		// std::string, and the reference handed back outlives it.
+		const std::string name(IMAGE);
+		const std::vector<unsigned char>& d = FakeFs::Contents(name);
+		size_t at = (size_t)lba * SECTOR + offsetInSector;
+		return at < d.size() ? d[at] : 0xFF;
+	}
+}
+
+// ---------------------------------------------------------------------------
+
+static void WriteThenFlushReachesTheCard()
+{
+	TEST_CASE("a flushed write reaches the card");
+	FreshImage();
+
+	ScsiImage img;
+	CHECK(img.Attach(IMAGE, false));
+
+	std::vector<u8> buf = Pattern(0x11);
+	CHECK_EQ(img.WriteSector(3, &buf[0]), 0);
+
+	// Nothing should have gone to the card yet - the write is acknowledged
+	// out of RAM, which is the whole design.
+	CHECK_EQ(OnCard(3), 0xAB);
+
+	CHECK_EQ(img.Sync(true), 0);
+	CHECK_EQ(OnCard(3), 0x11);
+	CHECK_EQ(OnCard(3, SECTOR - 1), 0x11);
+
+	// A second flush with nothing dirty must not touch the card.
+	unsigned before = FakeFs::WriteCallCount();
+	CHECK_EQ(img.Sync(true), 0);
+	CHECK_EQ(FakeFs::WriteCallCount(), before);
+
+	img.Detach();
+}
+
+// A full card reports FR_OK having written fewer bytes than asked. That used
+// to count as success, the dirty bits were cleared, and the only copy of the
+// data went away.
+static void ShortWriteIsNotSuccess()
+{
+	TEST_CASE("a short write is a failure, and the data survives it");
+	FreshImage();
+
+	ScsiImage img;
+	CHECK(img.Attach(IMAGE, false));
+
+	std::vector<u8> buf = Pattern(0x22);
+	CHECK_EQ(img.WriteSector(5, &buf[0]), 0);
+
+	FakeFs::ShortWritesAfter(0, 16);		// next write stores 16 of 512 bytes
+	CHECK(img.Sync(true) < 0);
+	CHECK(img.HasWriteError());
+
+	// The card has the truncated write on it, but the cache must still hold
+	// the sector as dirty - so once the card recovers, a flush completes it.
+	FakeFs::ShortWritesAfter(-1);
+	CHECK_EQ(img.Sync(true), 0);
+	CHECK_EQ(OnCard(5), 0x22);
+	CHECK_EQ(OnCard(5, SECTOR - 1), 0x22);
+
+	img.Detach();
+}
+
+static void HardWriteFailureKeepsTheData()
+{
+	TEST_CASE("a failed write keeps the data for a retry");
+	FreshImage();
+
+	ScsiImage img;
+	CHECK(img.Attach(IMAGE, false));
+
+	std::vector<u8> buf = Pattern(0x33);
+	CHECK_EQ(img.WriteSector(7, &buf[0]), 0);
+
+	FakeFs::FailWritesAfter(0);
+	CHECK(img.Sync(true) < 0);
+	CHECK_EQ(OnCard(7), 0xAB);				// nothing landed
+
+	// Reading it back must give the new data - it is still in the cache.
+	std::vector<u8> got(SECTOR, 0);
+	CHECK_EQ(img.ReadSector(7, &got[0]), 0);
+	CHECK_EQ(got[0], 0x33);
+
+	FakeFs::FailWritesAfter(-1);
+	CHECK_EQ(img.Sync(true), 0);
+	CHECK_EQ(OnCard(7), 0x33);
+
+	img.Detach();
+}
+
+// ReadSectorUncached checked the slot's valid flag but not the requested
+// sector's validMask bit, so a chunk created by writing one sector handed back
+// uninitialised RAM for the other seven - to the base LBA scan, which is what
+// decides where the CMD signature is.
+static void UncachedReadDoesNotInventData()
+{
+	TEST_CASE("an uncached read of an unwritten sector comes from the card");
+	FreshImage(0xAB);
+
+	ScsiImage img;
+	CHECK(img.Attach(IMAGE, false));
+
+	// Write sector 0 of chunk 0. Sectors 1..7 of that chunk are now present
+	// in the slot but hold nothing meaningful.
+	std::vector<u8> buf = Pattern(0x44);
+	CHECK_EQ(img.WriteSector(0, &buf[0]), 0);
+
+	for (u32 s = 1; s < PER_CHUNK; ++s)
+	{
+		std::vector<u8> got(SECTOR, 0);
+		CHECK_EQ(img.ReadSectorUncached(s, &got[0]), 0);
+		CHECK_MSG(got[0] == 0xAB, "unwritten sector should read as what is on the card");
+	}
+
+	// The written one still comes back from the cache.
+	std::vector<u8> got(SECTOR, 0);
+	CHECK_EQ(img.ReadSectorUncached(0, &got[0]), 0);
+	CHECK_EQ(got[0], 0x44);
+
+	img.Detach();
+}
+
+// The budget is what keeps a reset from taking the drive off the bus for
+// minutes. It was counted in chunks, which bounds the work only to within the
+// number of separate writes a chunk needs.
+static void FlushBudgetIsBounded()
+{
+	TEST_CASE("a budgeted flush stops near its deadline");
+	FreshImage();
+
+	ScsiImage img;
+	CHECK(img.Attach(IMAGE, false));
+
+	// Dirty a lot of separate chunks.
+	std::vector<u8> buf = Pattern(0x55);
+	for (u32 c = 0; c < 40; ++c)
+		CHECK_EQ(img.WriteSector(c * PER_CHUNK, &buf[0]), 0);
+
+	// Make each access cost the worst time measured on real hardware.
+	FakeClock::microsPerAccess = 35000;
+
+	u32 start = FakeClock::micros;
+	ScsiImage::FlushSome(250000);
+	u32 took = FakeClock::micros - start;
+
+	// Soft budget: it stops starting new work after the deadline, and a write
+	// already under way cannot be abandoned. One access of overrun is
+	// expected; ten would mean it is not bounded at all.
+	CHECK_MSG(took <= 250000 + 2 * 35000, "flush overran its budget by more than one access");
+	CHECK_MSG(took >= 100000, "flush gave up far too early to be doing real work");
+
+	// And it must not have marked itself clean - there is more to write.
+	unsigned before = FakeFs::WriteCallCount();
+	FakeClock::microsPerAccess = 0;
+	ScsiImage::FlushAll();
+	CHECK_MSG(FakeFs::WriteCallCount() > before, "the rest of the dirty chunks were never written");
+
+	img.Detach();
+}
+
+static void UnbudgetedFlushFinishesAndMarksClean()
+{
+	TEST_CASE("an unbudgeted flush finishes and marks the cache clean");
+	FreshImage();
+
+	ScsiImage img;
+	CHECK(img.Attach(IMAGE, false));
+
+	std::vector<u8> buf = Pattern(0x66);
+	for (u32 c = 0; c < 12; ++c)
+		CHECK_EQ(img.WriteSector(c * PER_CHUNK, &buf[0]), 0);
+
+	CHECK_EQ(ScsiImage::FlushAll(), 0);
+
+	for (u32 c = 0; c < 12; ++c)
+		CHECK_EQ(OnCard(c * PER_CHUNK), 0x66);
+
+	// Clean now: another flush must do no work at all.
+	unsigned before = FakeFs::WriteCallCount();
+	CHECK_EQ(ScsiImage::FlushAll(), 0);
+	CHECK_EQ(FakeFs::WriteCallCount(), before);
+
+	img.Detach();
+}
+
+// With the cache full and the card refusing writes, a chunk that cannot be
+// written must not be evicted - the cache is the only copy. WriteSector then
+// falls back to writing straight through and reports the failure honestly.
+static void EvictionDoesNotDiscardUnwritableData()
+{
+	TEST_CASE("eviction does not discard what it cannot write");
+	FreshImage();
+
+	ScsiImage img;
+	CHECK(img.Attach(IMAGE, false));
+
+	std::vector<u8> buf = Pattern(0x77);
+
+	// Fill the cache with dirty chunks.
+	for (u32 c = 0; c < 16; ++c)
+		CHECK_EQ(img.WriteSector(c * PER_CHUNK, &buf[0]), 0);
+
+	// Now break the card and keep writing, forcing evictions that cannot
+	// succeed. Some of these will fail, which is correct - what must not
+	// happen is a silent success that loses data.
+	FakeFs::FailWritesAfter(0);
+	int reported = 0;
+	for (u32 c = 16; c < 64; ++c)
+	{
+		if (img.WriteSector(c * PER_CHUNK, &buf[0]) != 0)
+			++reported;
+	}
+	CHECK_MSG(reported > 0, "writes against a dead card all claimed to succeed");
+
+	// Recover the card. Everything still held dirty must now land.
+	FakeFs::FailWritesAfter(-1);
+	ScsiImage::FlushAll();
+
+	img.Detach();
+}
+
+static void DetachOnADeadCardDoesNotPretend()
+{
+	TEST_CASE("detach on a dead card reports rather than pretending");
+	FreshImage();
+
+	ScsiImage img;
+	CHECK(img.Attach(IMAGE, false));
+
+	std::vector<u8> buf = Pattern(0x88);
+	CHECK_EQ(img.WriteSector(9, &buf[0]), 0);
+
+	u32 errorsBefore = ScsiImage::WriteErrorCount();
+	FakeFs::FailWritesAfter(0);
+	img.Detach();								// must not hang or crash
+
+	CHECK_MSG(ScsiImage::WriteErrorCount() > errorsBefore,
+		"a detach that lost data did not count an error");
+	CHECK_EQ(OnCard(9), 0xAB);					// nothing landed, as expected
+}
+
+// ---------------------------------------------------------------------------
+
+void RunScsiCacheTests()
+{
+	// One shot, and small so eviction is reachable: 64KB is 16 chunks.
+	ScsiImage::InitCache(64 * 1024);
+
+	WriteThenFlushReachesTheCard();
+	ShortWriteIsNotSuccess();
+	HardWriteFailureKeepsTheData();
+	UncachedReadDoesNotInventData();
+	FlushBudgetIsBounded();
+	UnbudgetedFlushFinishesAndMarksClean();
+	EvictionDoesNotDiscardUnwritableData();
+	DetachOnADeadCardDoesNotPretend();
+}


### PR DESCRIPTION
The emulation modules reach hardware through a handful of free functions and nothing else, so they can be built and exercised on a desktop compiler with no Pi in the loop. This puts that to work on the module that has produced the most bugs.

### The emulator sources are compiled unmodified

No `#ifdef TEST`, no dependency injection, no test-only constructors. The shims sit earlier on the include path than `src/`, so `ff.h`, `rpihardware.h`, `debug.h` and `integer.h` resolve to fakes and the code under test cannot tell.

That property is the valuable part. **If a header in `src/` ever has to change to make a test work, the seam has moved** — and the thing to fix is the seam, not the test. It's written down in `tests/README.md`.

### The fakes are built around failure

The FatFS fake keeps files in memory and can be made to fail on demand: short writes, hard errors, failing sync, failing seek. Those are the cases that matter, because a real card only behaves that way when it is dying and nobody is going to reproduce that on purpose.

The hardware fake serves a clock the tests drive by hand, and the filesystem fake charges it per access — so *"each SD access takes 35 ms"* becomes a variable rather than a sleep, and the flush budget can be tested in microseconds without a slow or flaky test.

### Eight cases, 135 checks

Each corresponds to a bug that reached `main` and was found by reading rather than by running:

- a flushed write reaches the card, and a clean cache does no I/O
- a short write is a failure, and the data survives it
- a hard write failure keeps the data for a retry
- an uncached read of an unwritten sector comes from the card, not from uninitialised cache RAM
- a budgeted flush stops near its deadline and leaves the rest dirty
- an unbudgeted flush finishes and marks the cache clean
- eviction does not discard what it could not write
- detach on a dead card reports rather than pretending

### They were checked against a deliberate regression

A suite that has only ever been green proves nothing. Removing the `written != run * SECTOR_SIZE` condition from `FlushChunk` turns three checks red:

```
FAIL  a short write is a failure, and the data survives it
        OnCard(5, SECTOR - 1) == 0x22
        got 171, expected 34
```

`171` is `0xAB` — the original fill byte, still on the card, because the tail of the sector never landed. That is the data loss made visible, and the run exits non-zero.

### CI

Tests with the sanitizers on (Linux has `libasan`; MinGW does not, hence `SANITIZE` defaulting off), plus `RASPPI` 0, 2 and 3 — targets that have broken independently before.

### What this does not do

These tests replace the hardware layer, so they **cannot catch a bug in it**. The `disk_ioctl` stub that failed every `CTRL_SYNC` — which made every successful flush report itself as a lost write — would pass all of this without complaint, because the fake's `f_sync` returns `FR_OK`.

That limit is documented rather than left to be rediscovered.

### Next

The SCSI command state machine is the obvious second suite: already a pure function of `(context, byte in) → (byte out, state)`, and it would have caught `REQUEST SENSE` never sending its payload, the unreachable medium-not-present branch, and the `REASSIGN BLOCKS` write past `data_buf`. Then the 65C02 against Klaus Dormann's functional suite, then register-level tests for the VIAs and RTC.

---

*Disclosure: written with Claude (Anthropic's Claude Code); the commit carries a `Co-Authored-By` trailer.*
