### PR TITLE
Clean automatically when the build target changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,26 @@ KERNEL  = $(TARGETDIR)/$(TARGET)
 
 all: $(KERNEL).img
 
+# Objects are built for one Pi and are not interchangeable - RASPPI selects
+# different -mcpu flags and different conditional code - but nothing in their
+# names or timestamps says which. Building for one target and then another
+# without cleaning silently reused the first target's objects; if you were
+# lucky it failed at link with missing symbols, and if you were not it linked
+# and produced a kernel for neither.
+#
+# So: a stamp named after the target. Asking for a different one finds no stamp
+# for it, and the tree is cleaned before anything is compiled.
+RASPPI_STAMP = $(TARGETDIR)/.built-for-$(RASPPI)
+
+$(RASPPI_STAMP):
+	@echo "  TARGET RASPPI=$(RASPPI) (cleaning: previous build was for another target)"
+	$(Q)$(RM) -r $(TARGETDIR)
+	$(Q)$(MAKE) -C uspi clean
+	@mkdir -p $(TARGETDIR)
+	@touch $@
+
+$(OBJS): $(RASPPI_STAMP)
+
 $(KERNEL).img: $(OBJS) $(LIBS)
 	@echo "  LINK $@"
 	$(Q)$(CC) $(CFLAGS) -o $(KERNEL).elf -Xlinker -Map=$(KERNEL).map -T linker.ld -nostartfiles $(OBJS) $(LIBS)


### PR DESCRIPTION
Objects are built for one Pi and are not interchangeable — `RASPPI` selects different `-mcpu` flags and different conditional code — but nothing in their names or timestamps records which one they are for. Since the build became incremental by default in `aad10b5`, building for one target and then another in the same tree reused the first target's objects.

**Found by doing it.** A Pi Zero build followed by a Pi 3 build failed at link with a page of missing symbols (`_spin_core`, `RPI_GpioVirtInit`, `Keyboard::Keyboard()`) that pointed nowhere useful.

That was the lucky case. Between two targets whose conditional code happens to line up, it would have linked and produced a kernel belonging to neither — which is precisely the "some of your changes, silently" failure that the dependency tracking was meant to end, arriving through a different door. My change, my omission.

### Fix

A stamp file named after the target. Asking for one that has no stamp cleans the tree, `uspi` included, before anything is compiled.

### Verified

- `build.bat 3` then `build.bat 0` — cleans, and both kernels come out at their expected sizes (363056 / 327056)
- Same target twice — no clean, and nothing recompiles
- Touch `rtc72421.h` — rebuilds exactly the three objects that include it

So the incremental behaviour is intact; only the target switch is caught.

---

*Disclosure: written with Claude (Anthropic's Claude Code); the commit carries a `Co-Authored-By` trailer.*
