### PR TITLE
Fix IEC bit corruption and bound the write-back cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,18 @@ quick from then on.
 // Only works once the image HAS a stored number - see "Device numbers" below.
 //CMDHDDeviceID = 0
 
-// Size in MB of the RAM cache in front of the DHD image (default 32)
-//CMDHDCacheMB = 32
+// Size in MB of the RAM cache in front of the DHD image (default 24).
+// Keeping a chunk in RAM keeps writes off the card, and an SD access freezes
+// the emulated drive for as long as it takes, so the cache is what stops the
+// computer deciding the drive has gone away. If the allocation fails the size
+// is halved until it fits; the ceiling on this hardware is about 32MB.
+//CMDHDCacheMB = 24
+
+// Size in MB pinned into the cache at mount, starting at sector 0 (default 18).
+// The partition header, BAM and directory live in the first few MB and are
+// touched constantly, so pinning them means they are never evicted. Set to 0
+// to disable, at the cost of a stall the first time each of them is read.
+//CMDHDPreloadMB = 18
 
 // GPIO used to pull the IEC ATN line low (0 = off, 24 on a Pi1541io).
 // Needed only so the SWAP buttons can reprogram another drive - see
@@ -380,9 +390,16 @@ ROM is not there and is gitignored - it is not ours to redistribute - and
 - Supported Pi models: 3B/3B+ recommended (RASPPI=3 build). The 2MHz 65C02
   plus two VIAs is more work per microsecond than a 1MHz 1541; Pi Zero
   builds compile but are not expected to keep up.
-- DHD images are streamed from the SD card through a write-through cache
+- DHD images are streamed from the SD card through a **write-back** cache
   (`CMDHDCacheMB`). A cache miss stalls the emulated CPU for the duration
   of the SD access, exactly as if the SCSI drive were slow to respond.
+- **Eject before you cut the power.** Because the cache is write-back, a
+  write the computer believes it has completed may still be in RAM. It
+  reaches the card when the bus has been quiet for half a second, when a
+  dirty chunk has to be evicted, or when the image is ejected - and during
+  a long operation like a GEOS installation the quiet moment may not come
+  at all. Ejecting from the menu, or exiting emulation, flushes everything.
+  Pulling the plug mid-session can lose the last writes.
 - Fast serial (C128 burst) is wired through U10's shift register at the bit
   level and SRQ is sampled/driven as the 1581 build did. C64 use (including
   JiffyDOS, which HDOS implements in software) is unaffected.

--- a/firmware/3b/options.txt
+++ b/firmware/3b/options.txt
@@ -46,8 +46,19 @@ CMDHDAtnOutGPIO = 24
 // brings it up on device 30 from the boot ROM.
 //CMDHDDeviceID = 0
 
-// Size in MB of the RAM cache in front of the DHD image.
-//CMDHDCacheMB = 32
+// Size in MB of the RAM cache in front of the DHD image. Keeping a chunk in
+// RAM keeps writes off the card, and an SD access freezes the emulated drive
+// for as long as it takes. Halved automatically if it will not fit; the
+// ceiling on this hardware is about 32MB.
+//
+// The cache is WRITE-BACK: eject before cutting the power, or the last writes
+// may still be in RAM. See the note in README.md.
+//CMDHDCacheMB = 24
+
+// Size in MB pinned into the cache at mount, from sector 0 (default 18). The
+// partition header, BAM and directory live there and are touched constantly.
+// Set to 0 to disable.
+//CMDHDPreloadMB = 18
 
 // Front panel buttons. The real CMD HD has four: SWAP 8, SWAP 9,
 // WRITE PROTECT and RESET. Button 5 exits emulation (not a CMD HD function).

--- a/src/emulation/iec_bus.cpp
+++ b/src/emulation/iec_bus.cpp
@@ -43,6 +43,9 @@ bool IEC_Bus::VIA_Clock = false;
 
 bool IEC_Bus::DataSetToOut = false;
 bool IEC_Bus::AtnaDataSetToOut = false;
+bool IEC_Bus::sampledDataSetToOut = false;
+bool IEC_Bus::sampledAtnaDataSetToOut = false;
+bool IEC_Bus::sampledClockSetToOut = false;
 bool IEC_Bus::ClockSetToOut = false;
 bool IEC_Bus::SRQSetToOut = false;
 bool IEC_Bus::AtnSetToOut = false;
@@ -75,11 +78,11 @@ u32 IEC_Bus::emulationModeCheckButtonIndex = 0;
 
 unsigned IEC_Bus::gplev0;
 
-void IEC_Bus::ReadGPIOUserInput()
+void IEC_Bus::ReadGPIOUserInput(unsigned step)
 {
 	for (int index = 0; index < buttonCount; ++index)
 	{
-		UpdateButton(index, gplev0);
+		UpdateButton(index, gplev0, step);
 	}
 }
 
@@ -128,13 +131,76 @@ void IEC_Bus::ReadBrowseMode(void)
 // the addition of SRQ for fast serial. The one difference that matters is the
 // ATN acknowledge gate: the CMD HD ANDs ATNA with ATN (like the 1581) rather
 // than XORing them (like the 1541).
+// A second, cheap look at the bus, taken between the two emulated CPU cycles.
+//
+// Why a trimmed one rather than another ReadEmulationModeCMDHD: that costs 156
+// cycles and does not fit - it was tried in fe3cdc2 and took the loop to 69
+// overruns per thousand. Of those 156, the blocking read of GPLEV0 is 69,
+// measured (PICMD-LST27.LOG, "read cost: gplev 69"), so most of the rest is
+// decoding that the second look does not need.
+//
+// What it deliberately does NOT do:
+//   - it does not touch PI_Data or PI_Clock. PI_Data feeds via10's CB2 in
+//     PiCMDHD::Update, and cb2 is the data bit of the fast serial shift
+//     register; moving it half a microsecond relative to the CB1 shift clock
+//     could change which side of an SRQ edge a bit lands on. That would
+//     manufacture corruption in the exact mechanism under investigation.
+//     The routines that need serving read ORB, which is portB's input latch.
+//   - it does not touch ATN, which is edge triggered into CA1 and whose
+//     acknowledge already runs on the full sample.
+//   - it does not write IEC_Bus::gplev0, which the front panel sampler reads
+//     once every 256 loops and which must keep meaning "the level at the top
+//     of the loop".
+//
+// The guards match the full sampler exactly: a line the drive is pulling low
+// itself cannot be sensed, because the pin is an output.
+void IEC_Bus::ReadBusInputsCMDHD(void)
+{
+	unsigned lev = read32(ARM_GPIO_GPLEV0);
+
+	IOPort* portB = port;
+	if (!portB)
+		return;
+
+	// The guards are a SNAPSHOT taken at the top of the loop, not the live
+	// flags, and that is the whole point.
+	//
+	// If the emulated CPU releases DATA or CLOCK during the first emulated
+	// cycle, PortB_OnPortOut puts that on the wire immediately. A live guard
+	// would be open by the time this runs a few hundred nanoseconds later, so
+	// we would sample a line that has not finished rising - open collector,
+	// pull-up, cable capacitance - and hand the drive back its own pull as if
+	// the computer were still asserting it. On the hardware that looks exactly
+	// like the fault this change exists to fix: a first symbol late or with a
+	// bit stuck low, and WORSE with the fix than without it.
+	//
+	// With the snapshot, a line released mid-loop is not sensed until the next
+	// top-of-loop sample, which is the timing the baseline has always had.
+#ifndef REAL_XOR
+	if (!sampledAtnaDataSetToOut && !sampledDataSetToOut)
+#else
+	if (!sampledDataSetToOut)
+#endif
+		portB->SetInput(VIAPORTPINS_DATAIN,
+			(lev & PIGPIO_MASK_IN_DATA) == (invertIECInputs ? PIGPIO_MASK_IN_DATA : 0));
+
+	if (!sampledClockSetToOut)
+		portB->SetInput(VIAPORTPINS_CLOCKIN,
+			(lev & PIGPIO_MASK_IN_CLOCK) == (invertIECInputs ? PIGPIO_MASK_IN_CLOCK : 0));
+}
+
 void IEC_Bus::ReadEmulationModeCMDHD(void)
 {
-	bool AtnaDataSetToOutOld = AtnaDataSetToOut;
-	IOPort* portB = 0;
 	gplev0 = read32(ARM_GPIO_GPLEV0);
 
-	portB = port;
+	IOPort* portB = port;
+
+	// Nearly every line below dereferences these, and the one null check that
+	// was here covered a single case out of five. Both are set together before
+	// emulation starts, so this only matters to a future caller that gets the
+	// order wrong - but then it matters as a hang, not a wrong bus level.
+	if (!portB || !VIA)
+		return;
 
 #ifndef REAL_XOR
 	// ATN is an input unless the drive itself is driving it (pb6), in which
@@ -167,7 +233,7 @@ void IEC_Bus::ReadEmulationModeCMDHD(void)
 		}
 	}
 
-	if (portB && (portB->GetDirection() & 0x10) == 0)
+	if ((portB->GetDirection() & 0x10) == 0)
 		AtnaDataSetToOut = false; // If the ATNA PB4 gets set to an input then we can't be pulling data low. (Maniac Mansion does this)
 
 	// moved from PortB_OnPortOut
@@ -245,6 +311,12 @@ void IEC_Bus::ReadEmulationModeCMDHD(void)
 	}
 
 	Resetting = !ignoreReset && ((gplev0 & PIGPIO_MASK_IN_RESET) == (invertIECInputs ? PIGPIO_MASK_IN_RESET : 0));
+
+	// What ReadBusInputsCMDHD will use half a microsecond from now. See the
+	// note there for why it must not read the live flags.
+	sampledDataSetToOut = DataSetToOut;
+	sampledAtnaDataSetToOut = AtnaDataSetToOut;
+	sampledClockSetToOut = ClockSetToOut;
 }
 
 void IEC_Bus::PortB_OnPortOut(void* pUserData, unsigned char status)
@@ -290,6 +362,27 @@ void IEC_Bus::PortB_OnPortOut(void* pUserData, unsigned char status)
 
 	ClockSetToOut = VIA_Clock;
 	DataSetToOut = VIA_Data;
+
+	// Put the change on the wire now rather than waiting for the main loop's
+	// once-per-microsecond refresh.
+	//
+	// The drive answers a strobe by writing this port and then counting NOPs:
+	// its first transmitted symbol is due about 14 cycles - 7us - after the
+	// poll that spotted the strobe, and the following three have 7.5 to 10us
+	// of slack. Deferring the write to the end of the microsecond spends up to
+	// 1us of that first budget for nothing, and the first symbol is where 404
+	// of 422 observed bit flips land.
+	//
+	// It is close to free: these flags only move when the CPU writes the port,
+	// which is four times per transmitted byte against roughly 35us of
+	// transfer, so the common case does not reach here at all. Writes to
+	// device memory are posted, so the store itself does not stall either.
+	if (DataSetToOut != oldDataSetToOut ||
+		ClockSetToOut != oldClockSetToOut ||
+		AtnaDataSetToOut != AtnaDataSetToOutOld)
+	{
+		RefreshOutsCMDHD();
+	}
 
 	//if (!oldDataSetToOut && DataSetToOut)
 	//{

--- a/src/emulation/iec_bus.h
+++ b/src/emulation/iec_bus.h
@@ -391,7 +391,15 @@ public:
 	}
 #endif
 
-	static void UpdateButton(int index, unsigned gplev0)
+	// step is how many sampling periods this call stands for. The thresholds
+	// above are counts of samples, and were written when every caller sampled
+	// once per microsecond; a caller that samples less often passes the
+	// divisor here so that 20000 keeps meaning 20 milliseconds instead of
+	// silently becoming five seconds - which is exactly what happened to every
+	// button on the front panel the first time this loop was decimated. The
+	// equality tests become crossed-this-call tests for the same reason: a
+	// step larger than one can jump straight over a threshold.
+	static void UpdateButton(int index, unsigned gplev0, unsigned step = 1)
 	{
 		bool inputcurrent = (gplev0 & ButtonPinFlags[index]) == 0;
 
@@ -400,15 +408,18 @@ public:
 
 		if (inputcurrent)
 		{
-			validInputCount[index]++;
-			if (validInputCount[index] == INPUT_BUTTON_DEBOUNCE_THRESHOLD)
+			unsigned before = validInputCount[index];
+			validInputCount[index] = before + step;
+			if (before < INPUT_BUTTON_DEBOUNCE_THRESHOLD &&
+				validInputCount[index] >= INPUT_BUTTON_DEBOUNCE_THRESHOLD)
 			{
 				InputButton[index] = true;
 				inputRepeatThreshold[index] = INPUT_BUTTON_DEBOUNCE_THRESHOLD + INPUT_BUTTON_REPEAT_THRESHOLD;
 				inputRepeat[index]++;
 			}
 
-			if (validInputCount[index] == inputRepeatThreshold[index])
+			if (before < inputRepeatThreshold[index] &&
+				validInputCount[index] >= inputRepeatThreshold[index])
 			{
 				inputRepeat[index]++;
 				inputRepeatThreshold[index] += INPUT_BUTTON_REPEAT_THRESHOLD / inputRepeat[index];
@@ -428,8 +439,9 @@ public:
 
 
 	static void ReadBrowseMode(void);
-	static void ReadGPIOUserInput(void);
+	static void ReadGPIOUserInput(unsigned step = 1);
 	static void ReadEmulationModeCMDHD(void);
+	static void ReadBusInputsCMDHD(void);
 
 	static void WaitUntilReset(void)
 	{
@@ -676,6 +688,11 @@ private:
 
 	static bool DataSetToOut;
 	static bool AtnaDataSetToOut;
+	// Snapshot of the three above, taken at the end of each full sample, for the
+	// trimmed mid-loop sample to use instead of the live flags.
+	static bool sampledDataSetToOut;
+	static bool sampledAtnaDataSetToOut;
+	static bool sampledClockSetToOut;
 	static bool ClockSetToOut;
 	static bool SRQSetToOut;
 	static bool AtnSetToOut;

--- a/src/emulation/m6522.cpp
+++ b/src/emulation/m6522.cpp
@@ -27,8 +27,22 @@ m6522::m6522()
 	Reset();
 }
 
+u32 m6522::srBytesIn = 0;
+u32 m6522::srEdgesWhileFull = 0;
+u32 m6522::srShortReads = 0;
+u32 m6522::srModeMask = 0;
+u32 m6522::srShiftsIn = 0;
+u32 m6522::srShiftsOut = 0;
+
 void m6522::Reset()
 {
+#if PICMD_SPLIT_CPUVIAS
+	idleSkips = 0; busyRuns = 0;
+	// Reset is what puts the VIA back to idle, so the sticky bits start clean
+	// with it - otherwise a session would inherit the previous mount's answer.
+	diagStartedT1 = 0; diagStartedT2 = 0; diagWroteACR = 0;
+	diagAcrLast = 0; diagIerLast = 0;
+#endif
 	functionControlRegister = 0;
 	auxiliaryControlRegister = 0;
 
@@ -65,7 +79,6 @@ void m6522::Reset()
 	t2LowTimedOut = false;
 	t2CountingPB6Mode = false;
 	t2CountingPB6ModeOld = false;
-	pb6Old = 0;
 	t2TimedOut = false;
 	t2OneShotTriggeredIRQ = false;
 
@@ -84,6 +97,9 @@ void m6522::Reset()
 	cb1OutputShiftClockPositiveEdge = false;
 	cb2Shift = 1;				// fast serial data line idles released
 	OutputIRQ();
+#if PICMD_VIA_IDLE_SKIP
+	UpdateIdleCache();
+#endif
 }
 
 void m6522::InputCA1(bool value)
@@ -141,6 +157,47 @@ void m6522::Execute()
 	if (ca2 && pulseCA2) ca2 = false;
 	if (cb2 && pulseCB2) cb2 = false;
 
+	// An idle VIA still costs about 76 ARM cycles per call, and there are four
+	// calls per emulated microsecond in a loop that has little to spare. On
+	// this machine U9 is idle for whole sessions - measured, not assumed:
+	// PICMD-LST33.LOG reports "idle at eject: U9 acr 00 t1 0 t2 0" while U10
+	// reports "acr 4c t1 1 t2 1", so the detector fires and the zero is real.
+	// Neither the CMD HD boot ROM nor the HDOS kernel writes U9's T1CH, T2CH
+	// or ACR at all.
+	//
+	// The predicate is ONE cached boolean on purpose. The first version tested
+	// nine pieces of state here and cost about 44 cycles - paid on all four
+	// calls while the saving is only collected on the two idle ones - so it
+	// came out 25 cycles per microsecond WORSE than no early-out at all
+	// (PICMD-LST31 against LST29). Every term now lives in idleCache, which is
+	// recomputed in Write() and Reset(), the only two places that can turn any
+	// of them on: while the cache is true nothing reachable sets t1Ticking,
+	// t2CountingDown, t1TimedOut, t2TimedOut, t1Reload or the pending shift
+	// clock edge, because every one of their setters is inside the code this
+	// skips. That is what makes caching safe rather than merely cheap.
+	//
+	// The two pulse tests above stay outside: they are what the function did
+	// first anyway, they are cheap, and keeping them out of the predicate is
+	// most of why it is now a single load.
+#if PICMD_VIA_IDLE_SKIP
+	if (idleCache)
+	{
+		// Faithful to the two assignments at the end of the function. cb1Old
+		// especially: dropping it would leave a stale level for the shift
+		// register's edge detector if ACR were written later.
+		cb1Old = cb1;
+		t2CountingPB6ModeOld = t2CountingPB6Mode;
+#if PICMD_SPLIT_CPUVIAS
+		idleSkips++;
+#endif
+		return;
+	}
+#endif
+#if PICMD_SPLIT_CPUVIAS
+	busyRuns++;
+#endif
+
+
 	// The t1 counter decrements on each succeeding phi2 from N to 0 and then one half phi2 cycle later IRQ goes active.
 	// (where N is the combined count value of T1CL and T1CH)
 	if (t1TimedOut)
@@ -192,8 +249,12 @@ void m6522::Execute()
 	}
 	t1Reload = false;
 
-	// Timer 2 can also be used to count negative pulses on the	PB6 line.
-	unsigned char pb6 = portB.GetInput() & ~portB.GetDirection() & 0x40;
+	// Timer 2's PB6 pulse counting mode is not emulated, and never was. What
+	// stood here read PB6 on every call to feed a negative edge test below
+	// that compared a value masked with 0x40 against 1 - so the test could
+	// never fire, for any guest, and the read was pure cost. Removing it is an
+	// exact equivalence. Making the mode actually work is a behaviour change
+	// and belongs in its own commit, with something that uses it to test.
 	unsigned char shiftMode = (auxiliaryControlRegister & ACR_SHIFTREG_CTRL) >> 2;
 
 	// The data is shifted into the shift register during the phi2 clock cycle following the positive going edge of the CB1 clock pulse.
@@ -252,11 +313,9 @@ void m6522::Execute()
 			// Bit 5 of the ACR determines whether the counter is decremented by the 6502 system clock or input pulses arriving on PB6.
 			if (t2CountingPB6Mode && t2CountingPB6ModeOld)
 			{
-				if (pb6 == 0 && pb6Old == 1)	// Was it the negative edge?
-				{
-					t2c.value--;
-					t2TimedOut = t2c.value == 0;
-				}
+				// The negative edge test that was here could not fire; see the
+				// note where pb6 was read. Counting stops in this mode, which
+				// is what the unreachable test amounted to anyway.
 			}
 			else
 			{
@@ -299,8 +358,16 @@ void m6522::Execute()
 			}
 		}
 	}
-	pb6Old = pb6;
 	t2CountingPB6ModeOld = t2CountingPB6Mode;
+
+#if PICMD_SPLIT_CPUVIAS
+	// Diagnostic only: this ran on every Execute call, four times per emulated
+	// microsecond, to answer a question that is asked once a session. The
+	// question is still open - see the note above srModeMask in the header -
+	// so it is switched out, not deleted.
+	if (shiftMode)
+		srModeMask |= (1 << shiftMode);
+#endif
 
 	switch (shiftMode)
 	{
@@ -313,7 +380,7 @@ void m6522::Execute()
 			{
 				// should output cb1OutputShiftClock onto cb1
 				shiftRegister <<= 1;
-				shiftRegister |= cb2;	// Should get from current cb2 (in a 1541 these pins on the VIAs are NC, measure at 5v and read as 1s)
+				shiftRegister |= cb2; srShiftsIn++;	// Should get from current cb2 (in a 1541 these pins on the VIAs are NC, measure at 5v and read as 1s)
 				if (++bitsShiftedSoFar == 8)
 					SetInterrupt(IR_SR);
 			}
@@ -327,7 +394,7 @@ void m6522::Execute()
 				// should output cb1OutputShiftClock onto cb1
 				cb1OutputShiftClock = !cb1OutputShiftClock;
 				shiftRegister <<= 1;
-				shiftRegister |= cb2;	// Should get from current cb2 (in a 1541 these pins on the VIAs are NC, measure at 5v and read as 1s)
+				shiftRegister |= cb2; srShiftsIn++;	// Should get from current cb2 (in a 1541 these pins on the VIAs are NC, measure at 5v and read as 1s)
 				if (++bitsShiftedSoFar == 8)
 					SetInterrupt(IR_SR);
 			}
@@ -341,9 +408,20 @@ void m6522::Execute()
 				if (!(bitsShiftedSoFar & 8))	// Shift register bug not implmented (would shift 9 bits?)
 				{
 					shiftRegister <<= 1;
-					shiftRegister |= cb2;	// Should get from current cb2 (in a 1541 these pins on the VIAs are NC, measure at 5v and read as 1s)
+					shiftRegister |= cb2; srShiftsIn++;	// Should get from current cb2 (in a 1541 these pins on the VIAs are NC, measure at 5v and read as 1s)
 					if (++bitsShiftedSoFar == 8)
+					{
 						SetInterrupt(IR_SR);
+						srBytesIn++;
+					}
+				}
+				else
+				{
+					// A clock edge with a full byte still sitting in the
+					// register. On the CMD HD's fast serial that is a bit the
+					// sender meant for the next byte and we have nowhere to put
+					// - the far end and this one have lost step.
+					srEdgesWhileFull++;
 				}
 			}
 		break;
@@ -351,7 +429,7 @@ void m6522::Execute()
 			if (shiftClockPositiveEdge)	// in this mode	the shift register counter is disabled.
 			{
 				cb2Shift = (shiftRegister & 0x80) != 0;
-				shiftRegister = (shiftRegister << 1) | cb2Shift;
+				shiftRegister = (shiftRegister << 1) | cb2Shift; srShiftsOut++;
 				// should output cb1OutputShiftClock onto cb1
 				// cb2Shift should output to cb2
 				//	- R/!W (on the 2nd VIA could be dangerous)
@@ -361,7 +439,7 @@ void m6522::Execute()
 			if ((t2TimedOutCount > 2) && shiftClockPositiveEdge && !(bitsShiftedSoFar & 8))
 			{
 				cb2Shift = (shiftRegister & 0x80) != 0;
-				shiftRegister = (shiftRegister << 1) | cb2Shift;
+				shiftRegister = (shiftRegister << 1) | cb2Shift; srShiftsOut++;
 				if (++bitsShiftedSoFar == 8)
 					SetInterrupt(IR_SR);
 				// should output cb1OutputShiftClock onto cb1
@@ -379,7 +457,7 @@ void m6522::Execute()
 				if (!cb1OutputShiftClock)
 				{
 					cb2Shift = (shiftRegister & 0x80) != 0;
-					shiftRegister = (shiftRegister << 1) | cb2Shift;
+					shiftRegister = (shiftRegister << 1) | cb2Shift; srShiftsOut++;
 					if (++bitsShiftedSoFar == 8)
 						SetInterrupt(IR_SR);
 				}
@@ -396,7 +474,7 @@ void m6522::Execute()
 					// should output cb1OutputShiftClock onto cb1
 					cb1OutputShiftClock = !cb1OutputShiftClock;
 					cb2Shift = (shiftRegister & 0x80) != 0;
-					shiftRegister = (shiftRegister << 1) | cb2Shift;
+					shiftRegister = (shiftRegister << 1) | cb2Shift; srShiftsOut++;
 					if (++bitsShiftedSoFar == 8)
 						SetInterrupt(IR_SR);
 					// cb2Shift should output to cb2
@@ -460,7 +538,10 @@ unsigned char m6522::Read(unsigned int address)
 		break;
 		case SR:
 			value = shiftRegister;
-			if (interruptFlagRegister & IR_SR) bitsShiftedSoFar = 0;
+			if (interruptFlagRegister & IR_SR)
+				bitsShiftedSoFar = 0;
+			else if (bitsShiftedSoFar)
+				srShortReads++;		// read mid byte: the rest arrives as ones
 			ClearInterrupt(IR_SR);
 		break;
 		case ACR:
@@ -566,6 +647,9 @@ void m6522::Write(unsigned int address, unsigned char value)
 			t1l.bytes.l = value;
 		break;
 		case T1CH:
+#if PICMD_SPLIT_CPUVIAS
+			diagStartedT1 = 1;
+#endif
 			// A write to TICH loads both the high order counter and high order latch with the same value.
 			// Simultaneously the T1LL contents are transferred to the low order counter and the count begins.
 			// If PB7 has been programmed as a TIMER 1 output it will go low on the phi2 following the write operation.
@@ -612,6 +696,9 @@ void m6522::Write(unsigned int address, unsigned char value)
 			t2Latch = value;
 		break;
 		case T2CH:
+#if PICMD_SPLIT_CPUVIAS
+			diagStartedT2 = 1;
+#endif
 			// Writing T2CH loads an 8 bit byte into the high order counter and latch (!!!there is no t2lh!!!) and simultaneously loads the low order latch into the low order counter, and the count down is initiated.
 			// If a T2 interrupt has occurred, the write operation will clear the T2 interrupt flag and reset !IRQ.
 			t2c.bytes.h = value;
@@ -632,6 +719,10 @@ void m6522::Write(unsigned int address, unsigned char value)
 			cb1OutputShiftClockPositiveEdge = false;
 		break;
 		case ACR:
+#if PICMD_SPLIT_CPUVIAS
+			diagWroteACR = 1;
+			diagAcrLast = value;
+#endif
 			//bool t1OutPB7Prev = (auxiliaryControlRegister & ACR_T1_OUT_PB7) != 0;
 			auxiliaryControlRegister = value;
 			latchPortA = (value & ACR_PA_LATCH_ENABLE) != 0;
@@ -704,6 +795,9 @@ void m6522::Write(unsigned int address, unsigned char value)
 			ClearInterrupt(value);
 		break;
 		case IER:
+#if PICMD_SPLIT_CPUVIAS
+			diagIerLast = value;
+#endif
 			// If bit 7 is a 0, each 1 in bits 6 through 0 clears the corresponding bit in the IER.
 			// For each zero in bits 6 through 0, the corresponding bit is unaffected.
 			if (value & IR_IRQ) interruptEnabledRegister |= value;
@@ -715,4 +809,7 @@ void m6522::Write(unsigned int address, unsigned char value)
 			WritePortA(value, false);
 		break;
 	}
+#if PICMD_VIA_IDLE_SKIP
+	UpdateIdleCache();
+#endif
 }

--- a/src/emulation/m6522.h
+++ b/src/emulation/m6522.h
@@ -143,6 +143,21 @@ class m6522
 	};
 
 public:
+	// Fast serial diagnostics. The CMD HD carries GEOS traffic through this
+	// shift register, and bytes have been arriving with their low bits set -
+	// which is what an extra clock edge sampling the idle line looks like.
+	// srEdgesWhileFull counts edges with no room left, srShortReads counts the
+	// CPU taking the byte before eight bits are in.
+	static u32 srBytesIn;
+	static u32 srEdgesWhileFull;
+	static u32 srShortReads;
+	// Which shift modes have ever been active (bit N = mode N), and how many
+	// bits have actually moved each way. Mode 3 alone stayed at zero, so the
+	// question is which one the CMD HD really drives.
+	static u32 srModeMask;
+	static u32 srShiftsIn;
+	static u32 srShiftsOut;
+
 /*
 FCR/PCR
 						+---+---+---+---+---+---+---+---+
@@ -214,8 +229,66 @@ FCR/PCR
 	unsigned char GetLatchedValueB() { return latchedValueB; }
 	inline bool GetCB1() { return cb1; }
 	void InputCB1(bool value);
+	// Called once per emulated CPU cycle from PiCMDHD::Update whether or not
+	// the line has moved, which on a C64 is almost always. Both bodies do
+	// nothing at all when the new level equals the old one, so the test can be
+	// hoisted here and the call saved - four calls per emulated microsecond
+	// that no longer leave the header.
+	//
+	// The comparison has to be against the VIA's own cb1/cb2 and nothing else.
+	// cb2 in particular is also cleared by the CPU writing ORB in handshake
+	// mode and by pulse mode in Execute, so a level cached outside this object
+	// would miss an edge - and a missed fast serial edge is a corrupted bit in
+	// exactly the mechanism under investigation.
+#if PICMD_VIA_IDLE_SKIP
+	// True when Execute() would provably do nothing but its two trailing
+	// assignments. Recomputed only in Write() and Reset(), which are the only
+	// places that can turn any of these on - while it is true, every setter of
+	// every term below sits inside the code the early-out skips, so the cache
+	// cannot go stale. Cheap on purpose: the version that tested all of this
+	// per call cost more than it saved.
+	void UpdateIdleCache()
+	{
+		idleCache = (auxiliaryControlRegister == 0)
+			&& !t1Ticking && !t2CountingDown
+			&& !t1TimedOut && !t2TimedOut && !t1Reload
+			&& !cb1OutputShiftClockPositiveEdge;
+	}
+#endif
+
+	// Always available, not diagnostic: the deployed build reports these at
+	// eject so a session that woke U9 up says so.
+	unsigned char AcrValue() const { return auxiliaryControlRegister; }
+	bool T1Ticking() const { return t1Ticking; }
+	bool T2Counting() const { return t2CountingDown; }
+
+#if PICMD_SPLIT_CPUVIAS
+	// How often the idle early-out in Execute actually fires. A saving that is
+	// only taken some of the time is worth only that fraction, and this
+	// project has been wrong about frequencies before.
+	u32 idleSkips, busyRuns;
+	u32 IdleSkips() const { return idleSkips; }
+	u32 BusyRuns() const { return busyRuns; }
+#endif
+	inline void InputCB1Level(bool value) { if (value != cb1) InputCB1(value); }
+	inline void InputCB2Level(bool value) { if (value != cb2) InputCB2(value); }
 	inline bool GetCB2() { return cb2; }
 	void InputCB2(bool value);
+
+#if PICMD_SPLIT_CPUVIAS
+	// M1: has this VIA ever left idle? t1Ticking and t2CountingDown are only
+	// cleared in Reset, so a single write to T1CH or T2CH decides for the whole
+	// session whether an early-out in Execute() can ever fire. Sticky rather
+	// than sampled: the answer must not depend on when we looked. Set in
+	// Write(), which only runs when the 65C02 addresses the VIA, so this costs
+	// the emulation loop nothing at all.
+	u8 diagStartedT1, diagStartedT2, diagWroteACR, diagAcrLast, diagIerLast;
+	u8 DiagFlags() const { return (u8)((diagStartedT1 ? 1 : 0) | (diagStartedT2 ? 2 : 0) | (diagWroteACR ? 4 : 0)); }
+	u8 DiagAcr() const { return diagAcrLast; }
+	u8 DiagIer() const { return diagIerLast; }
+	bool DiagT1Ticking() const { return t1Ticking; }
+	bool DiagT2Counting() const { return t2CountingDown; }
+#endif
 
 	void Execute();
 
@@ -352,6 +425,9 @@ private:
 	unsigned char latchedValueB;
 	bool cb1;
 	bool cb1Old;
+#if PICMD_VIA_IDLE_SKIP
+	bool idleCache;
+#endif
 	bool cb2;
 	bool pulseCB2;
 
@@ -376,7 +452,8 @@ private:
 	bool t2LowTimedOut;
 	bool t2OneShotTriggeredIRQ;
 	unsigned t2TimedOutCount;
-	unsigned char pb6Old;
+	// pb6Old removed: the negative edge test it fed compared a value masked
+	// with 0x40 against 1, so it could never be true. See the note in Execute.
 
 	unsigned char interruptFlagRegister;
 	unsigned char interruptEnabledRegister;

--- a/src/emulation/m65c02.h
+++ b/src/emulation/m65c02.h
@@ -68,6 +68,14 @@ private:
 	}												\
 	else addressModeCycleFn = &M65C02::InstructionFetch;
 
+
+static inline u32 PiCMDArmCycles(void)
+{
+	u32 v;
+	asm volatile ("mrc p15,0,%0,c9,c13,0" : "=r" (v));
+	return v;
+}
+
 class M65C02
 {
 private:

--- a/src/emulation/picmdhd.cpp
+++ b/src/emulation/picmdhd.cpp
@@ -63,6 +63,22 @@ enum
 #define VIA_REG_ORA    1
 #define VIA_REG_ORA_NH 15
 
+#if PICMD_SPLIT_CPUVIAS
+u64 PiCMDHD::subCycles[3];
+u32 PiCMDHD::subSamples = 0;
+u32 PiCMDHD::diagReadCost[4];
+#endif
+u32 PiCMDHD::armClockHz = 0;
+u32 PiCMDHD::lostCycles = 0;
+u32 PiCMDHD::lostHist[16];
+u64 PiCMDHD::loopIterations = 0;
+u64 PiCMDHD::sectionCycles[4];
+u32 PiCMDHD::worstLostUs = 0;
+u32 PiCMDHD::scsiBusReads = 0;
+u32 PiCMDHD::scsiBusMismatches = 0;
+u8 PiCMDHD::scsiBusMismatchXor = 0;
+u8 PiCMDHD::scsiBusMismatchDdr = 0;
+
 ///////////////////////////////////////////////////////////////////////////////
 // CPU bus functions
 ///////////////////////////////////////////////////////////////////////////////
@@ -329,6 +345,7 @@ void PiCMDHD::Initialise()
 	scanNeeded = true;
 	LEDs = 0;
 	forcedDeviceID = 0;
+	preloadMB = 0;
 	headPosition = 0;
 	imagesize = 0;
 	baselba = INVALID_BASELBA;
@@ -338,6 +355,7 @@ void PiCMDHD::Initialise()
 	virtualButtonCountdown = 0;
 	virtualButtonMask = 0;
 	fastSerialDirection = FAST_SERIAL_DIR_IN;
+	rtcTickCountdown = RTC_TICK_CYCLES;
 
 	memset(ram, 0, sizeof(ram));
 	memset(&scsi, 0, sizeof(scsi));
@@ -571,6 +589,22 @@ bool PiCMDHD::Insert(const char* filename, bool readOnly)
 	scanNeeded = true;
 	FindBaseLBA();
 
+	// Pull the working area of the image into RAM while nothing is listening.
+	// A cache miss costs an SD access, an SD access freezes the emulated CPU
+	// for tens of milliseconds, and the bus gives up on us long before that -
+	// so the miss that lands in the middle of a transfer is fatal. Paying for
+	// them all here, once, is the whole point.
+	if (preloadMB)
+	{
+		disk[0].PreloadCache(preloadMB * 1024 * 1024, &scanSector, &scanTotal);
+	}
+
+	// The scan above walks the whole image off the card, so it sets the stall
+	// watermark and the read counters before the computer has asked for
+	// anything. Start the figures here, or they describe the mount instead of
+	// whatever goes wrong afterwards.
+	ScsiImage::ResetCounters();
+
 	// look to see if there are more files with the same base name, but
 	// s<ID><LUN> extensions: s01, ..., s10, ..., s67 (VICE convention)
 	int len = (int)strlen(filename);
@@ -610,6 +644,154 @@ bool PiCMDHD::Insert(const char* filename, bool readOnly)
 
 void PiCMDHD::Eject()
 {
+	// Last chance to get the access log off the machine. The bus is finished
+	// with us by now, so the card can take as long as it likes. Done before
+	// the Detach loop only so a failure here cannot leave an image attached.
+	// The two numbers this build exists for, written where they cannot be lost
+	// to somebody forgetting to photograph the screen. Eject only, so it costs
+	// the emulation loop nothing.
+	{
+		char name[32];
+		FILINFO fno;
+		for (unsigned n = 0; n <= 99; ++n)
+		{
+			snprintf(name, sizeof(name), "PICMD-LST%02u.LOG", n);
+			if (f_stat(name, &fno) == FR_OK)
+				continue;
+			FIL fp;
+			if (f_open(&fp, name, FA_CREATE_ALWAYS | FA_WRITE) == FR_OK)
+			{
+				char line[128];
+				UINT written;
+				int len = snprintf(line, sizeof(line),
+					"arm %u Hz  budget %u cycles/us\r\n",
+					PiCMDHD::armClockHz, PiCMDHD::armClockHz / 1000000);
+				if (len > 0)
+					f_write(&fp, line, (UINT)len, &written);
+				len = snprintf(line, sizeof(line),
+					"loops %llu  lost %u (%u per mille, %u ppm)  worst %u us\r\n",
+					(unsigned long long)PiCMDHD::loopIterations, PiCMDHD::lostCycles,
+					PiCMDHD::loopIterations
+						? (u32)((u64)PiCMDHD::lostCycles * 1000
+							/ PiCMDHD::loopIterations) : 0,
+					PiCMDHD::loopIterations
+						? (u32)((u64)PiCMDHD::lostCycles * 1000000
+							/ PiCMDHD::loopIterations) : 0,
+					PiCMDHD::worstLostUs);
+				if (len > 0)
+					f_write(&fp, line, (UINT)len, &written);
+#if PICMD_SPLIT_CPUVIAS
+				len = snprintf(line, sizeof(line),
+					"read cost: gplev %u  filler %u  gplev+filler %u  systimer %u\r\n",
+					PiCMDHD::diagReadCost[0], PiCMDHD::diagReadCost[1],
+					PiCMDHD::diagReadCost[2], PiCMDHD::diagReadCost[3]);
+				if (len > 0)
+					f_write(&fp, line, (UINT)len, &written);
+				len = snprintf(line, sizeof(line),
+					"U9  everT1 %u everT2 %u everACR %u  acr %02x ier %02x  ticking %u/%u\r\n",
+					(via9.DiagFlags() & 1) ? 1u : 0u, (via9.DiagFlags() & 2) ? 1u : 0u,
+					(via9.DiagFlags() & 4) ? 1u : 0u, via9.DiagAcr(), via9.DiagIer(),
+					via9.DiagT1Ticking() ? 1u : 0u, via9.DiagT2Counting() ? 1u : 0u);
+				if (len > 0)
+					f_write(&fp, line, (UINT)len, &written);
+				len = snprintf(line, sizeof(line),
+					"idle skips: U9 %u / %u runs   U10 %u / %u runs\r\n",
+					via9.IdleSkips(), via9.IdleSkips() + via9.BusyRuns(),
+					via10.IdleSkips(), via10.IdleSkips() + via10.BusyRuns());
+				if (len > 0)
+					f_write(&fp, line, (UINT)len, &written);
+				len = snprintf(line, sizeof(line),
+					"U10 everT1 %u everT2 %u everACR %u  acr %02x ier %02x  ticking %u/%u\r\n",
+					(via10.DiagFlags() & 1) ? 1u : 0u, (via10.DiagFlags() & 2) ? 1u : 0u,
+					(via10.DiagFlags() & 4) ? 1u : 0u, via10.DiagAcr(), via10.DiagIer(),
+					via10.DiagT1Ticking() ? 1u : 0u, via10.DiagT2Counting() ? 1u : 0u);
+				if (len > 0)
+					f_write(&fp, line, (UINT)len, &written);
+				if (PiCMDHD::subSamples)
+				{
+					static const char* subNames[3] = {
+						"  65c02 Step      ", "  via9+via10 Exec ", "  rest of Update  " };
+					for (u32 k = 0; k < 3; k++)
+					{
+						len = snprintf(line, sizeof(line),
+							"%s: %u cycles per emulated CPU cycle\r\n", subNames[k],
+							(u32)(PiCMDHD::subCycles[k] / PiCMDHD::subSamples));
+						if (len > 0)
+							f_write(&fp, line, (UINT)len, &written);
+					}
+				}
+#endif
+				// The single card operation that took longest, from NoteStall.
+				// It belongs next to "worst" above because the two answer
+				// different questions and the difference is the whole point:
+				// "worst" is the longest the emulation loop overran, which
+				// includes however many card writes one visit to the flush
+				// batched together; this is the longest ONE of them took. When
+				// they are equal the batching is gone and what is left is the
+				// card's own tail latency, which is nothing this code can fix.
+				len = snprintf(line, sizeof(line),
+					"worst single SD access: %u us\r\n",
+					ScsiImage::WorstStallMicros());
+				if (len > 0)
+					f_write(&fp, line, (UINT)len, &written);
+
+				// Loud on purpose, and printed even when zero so that a zero
+				// is a statement rather than an absence. Anything else here is
+				// user data the card refused and that was dropped when the
+				// image detached.
+				len = snprintf(line, sizeof(line),
+					"UNFLUSHED SECTORS AT DETACH: %u\r\n",
+					ScsiImage::UnflushedSectors());
+				if (len > 0)
+					f_write(&fp, line, (UINT)len, &written);
+
+				// Free, and it answers the one question the deployed build
+				// otherwise cannot: whether U9 stayed idle for the whole
+				// session. t1Ticking and t2CountingDown are latches that only
+				// Reset clears, so reading them here IS the sticky answer, and
+				// if U9 ever woke up the idle skip in Execute stopped paying
+				// from that moment on with nothing in the log to say so.
+				len = snprintf(line, sizeof(line),
+					"idle at eject: U9 acr %02x t1 %u t2 %u   U10 acr %02x t1 %u t2 %u\r\n",
+					via9.AcrValue(), via9.T1Ticking() ? 1u : 0u, via9.T2Counting() ? 1u : 0u,
+					via10.AcrValue(), via10.T1Ticking() ? 1u : 0u, via10.T2Counting() ? 1u : 0u);
+				if (len > 0)
+					f_write(&fp, line, (UINT)len, &written);
+#if PICMD_SECTION_PROBES
+				static const char* names[4] = {
+					"read IEC ", "cpu+vias ", "drive IEC", "leds+btns" };
+				for (u32 sec = 0; sec < 4; sec++)
+				{
+					len = snprintf(line, sizeof(line),
+						"  %s : %u cycles/loop avg\r\n", names[sec],
+						PiCMDHD::loopIterations
+							? (u32)(PiCMDHD::sectionCycles[sec]
+								/ PiCMDHD::loopIterations) : 0);
+					if (len > 0)
+						f_write(&fp, line, (UINT)len, &written);
+				}
+#endif
+				for (u32 b = 2; b < 16; b++)
+				{
+					if (!PiCMDHD::lostHist[b])
+						continue;
+					len = snprintf(line, sizeof(line),
+						"  overran by %2u us : %u\r\n", b - 1,
+						PiCMDHD::lostHist[b]);
+					if (len > 0)
+						f_write(&fp, line, (UINT)len, &written);
+				}
+				f_close(&fp);
+			}
+			break;
+		}
+	}
+
+#if PICMD_ACCESS_FORENSICS
+	ScsiImage::DumpAccessLog("PICMD-LBA");
+	ScsiImage::DumpWriteLog("PICMD-WR");
+#endif
+
 	for (int i = 0; i < SCSI_MAX_DISKS; i++)
 	{
 		disk[i].Detach();
@@ -664,8 +846,24 @@ u8 PiCMDHD::Read(u16 address)
 			if (reg == VIA_REG_ORA || reg == VIA_REG_ORA_NH)
 			{
 				// Reading the SCSI data bus; PRA accesses generate ACK.
-				via9.GetPortA()->SetInput(scsi_get_bus(&scsi));
+				u8 bus = scsi_get_bus(&scsi);
+				via9.GetPortA()->SetInput(bus);
 				value = via9.Read(reg);
+				// Did the CPU get what the bus was holding? See the note on
+				// scsiBusReads in the header: a direction bit left as an
+				// output, or a stale CA1 latch, both replace bus bits here,
+				// and on an inverted bus that arrives as ones in the data.
+				if (scsi.io)
+				{
+					scsiBusReads++;
+					if (value != bus)
+					{
+						u8 differing = (u8)(value ^ bus);
+						scsiBusMismatches++;
+						scsiBusMismatchXor |= differing;
+						scsiBusMismatchDdr |= (u8)(via9.GetPortA()->GetDirection() & differing);
+					}
+				}
 				if (scsi.state != SCSI_STATE_BUSFREE && reg == VIA_REG_ORA)
 				{
 					scsi_process_ack(&scsi);
@@ -854,10 +1052,59 @@ void PiCMDHD::Write(u16 address, u8 value)
 // Per cycle update
 ///////////////////////////////////////////////////////////////////////////////
 
+// Called from the once-every-256-loops block in EmulateCMDHD, with the number
+// of emulated CPU cycles that have passed since the last call. Everything here
+// used to run per emulated cycle and does not need to.
+//
+// The tests are crossings, not equalities, and the reason is narrower than it
+// first looks - worth writing down, because the obvious justification is wrong.
+// The cold boot countdown IS an exact multiple of the step (16,000,000 = 512 x
+// 31,250), so "== 0" would have worked there and hidden the bug. It is the warm
+// reset countdown of 1,000,000 that leaves a remainder of 64 and would step
+// straight over zero, underflow, and leave SWAP8 and SWAP9 virtually held for
+// another four billion cycles - the drive stuck in installation mode after a
+// front panel reset but not after a power cycle, which is exactly the kind of
+// fault that takes a week to pin down. RTC_TICK_CYCLES has the same remainder.
+// The same trap took out every front panel button the first time this loop was
+// decimated - see UpdateButton in iec_bus.h.
+void PiCMDHD::SlowTick(u32 emulatedCycles)
+{
+	if (rtcTickCountdown > emulatedCycles)
+	{
+		rtcTickCountdown -= emulatedCycles;
+	}
+	else
+	{
+		rtcTickCountdown = RTC_TICK_CYCLES;
+		rtc.Tick();
+	}
+
+	if (virtualButtonCountdown)
+	{
+		if (virtualButtonCountdown > emulatedCycles)
+		{
+			virtualButtonCountdown -= emulatedCycles;
+		}
+		else
+		{
+			virtualButtonCountdown = 0;
+			virtualButtonMask = 0;
+			UpdateButtonInputs();
+		}
+	}
+}
+
 void PiCMDHD::Update()
 {
+#if PICMD_SPLIT_CPUVIAS
+	u32 t0 = PiCMDArmCycles();
+#endif
 	via9.Execute();
 	via10.Execute();
+#if PICMD_SPLIT_CPUVIAS
+	u32 t1 = PiCMDArmCycles();
+	subCycles[1] += (u32)(t1 - t0);
+#endif
 
 	// Wire-OR the two VIA IRQ outputs onto the CPU IRQ line.
 	if (via9IRQ.IsAsserted() || via10IRQ.IsAsserted())
@@ -875,17 +1122,24 @@ void PiCMDHD::Update()
 	else
 	{
 		// DATA is sent to CB2, SRQ is sent to CB1.
-		via10.InputCB2(!IEC_Bus::GetPI_Data());	// Communication on fast serial is done before the inverter.
-		via10.InputCB1(IEC_Bus::GetPI_SRQ());
+		// PI_Data and PI_SRQ are deliberately NOT refreshed by the trimmed
+		// mid-loop sample, so both calls see the same value on the second
+		// emulated cycle as on the first. Do not "fix" that. It keeps CB2, the
+		// fast serial data bit, in a fixed phase against the CB1 shift clock -
+		// moving it half a microsecond could change which side of an SRQ edge a
+		// bit lands on, which manufactures corruption in the mechanism under
+		// investigation - and it is also what makes the level guards below hit
+		// every second call.
+		via10.InputCB2Level(!IEC_Bus::GetPI_Data());	// Communication on fast serial is done before the inverter.
+		via10.InputCB1Level(IEC_Bus::GetPI_SRQ());
 	}
 
-	// Installation mode holds SWAP8+SWAP9 virtually for a while after reset.
-	if (virtualButtonCountdown)
-	{
-		if (--virtualButtonCountdown == 0)
-		{
-			virtualButtonMask = 0;
-			UpdateButtonInputs();
-		}
-	}
+	// The RTC tick and the virtual button countdown used to live here, one
+	// decrement each per emulated CPU cycle. They are now in SlowTick below:
+	// both have periods measured in hundreds of thousands of cycles, so a
+	// quarter of a millisecond of granularity is nothing, and two decrements
+	// out of the hot path is real.
+#if PICMD_SPLIT_CPUVIAS
+	subCycles[2] += (u32)(PiCMDArmCycles() - t1);
+#endif
 }

--- a/src/emulation/picmdhd.h
+++ b/src/emulation/picmdhd.h
@@ -37,13 +37,15 @@
 #include "rtc72421.h"
 #include "scsi.h"
 
+
 class PiCMDHD
 {
 public:
 	PiCMDHD();
 
 	void Initialise();
-	void Update();		// One 2MHz CPU cycle worth of house keeping.
+	void Update();
+	void SlowTick(u32 emulatedCycles);		// One 2MHz CPU cycle worth of house keeping.
 	void Reset();
 
 	// Attach the DHD image (SCSI ID 0 LUN 0) plus any companion .sXY files.
@@ -130,6 +132,90 @@ public:
 	// patched to this unit number on the fly (VICE behaviour). If zero the
 	// image's own device number is respected.
 	void SetForcedDeviceID(u8 id) { forcedDeviceID = id; }
+	// Megabytes of the image to pull into the cache at mount. Must be set
+	// before Insert; 0 leaves the cache cold.
+	void SetPreloadMB(unsigned mb) { preloadMB = mb; }
+
+	// What the SCSI data bus offered on a port A read against what the CPU
+	// actually took away. m6522::ReadPortA returns
+	// (input & ~ddr) | (output & ddr), and the bus only ever arrives through
+	// SetInput, so any DDRA bit still set as an output silently serves the
+	// port's own stale latch in place of a real bus bit. The bus is inverted
+	// (scsi_process_ack does databus ^ 0xff), so a zero smuggled in that way
+	// reaches the sector buffer as a one - which is exactly the | 0x03 that
+	// has been eating the BAM and directory sectors. Counted only while the
+	// target drives the bus.
+	//   Xor  = every bit that has ever differed.
+	//   Ddr  = of those, the ones DDRA had as outputs. Equal to Xor means the
+	//          direction merge explains all of it; zero with mismatches means
+	//          it is the CA1 latch path instead.
+	// Microseconds the main loop overran its 1us budget. Pi1541 has always had
+	// the test for this in main.cpp with an empty body and a commented-out
+	// log, beside its author's note that it can make emulation fail inside
+	// critical communication loops. This build exists to measure it with
+	// NOTHING else added, so the number cannot be blamed on the
+	// investigation's own instrumentation.
+	// Split of the cpu+vias section, which is 669 of the loop's ~1120 real
+	// cycles and has always been one opaque number. Diagnostic only: it adds
+	// four more coprocessor reads per emulated CPU cycle, so a kernel built
+	// with it WILL overrun the microsecond and the drive will misbehave. That
+	// is fine - the point is the ratio between the parts, not a working drive.
+	// Mount, open a directory, eject, read the numbers, build it out again.
+	//   0 = m65c02::Step   1 = via9+via10 Execute   2 = rest of Update
+	// Behind the switch so that turning it off rebuilds the deployed kernel
+	// byte for byte rather than merely equivalently.
+#if PICMD_SPLIT_CPUVIAS
+	static u64 subCycles[3];
+	static u32 subSamples;
+
+	// M2: what a blocking read of Device memory actually costs. The figure
+	// "about 100 cycles for read32(ARM_GPIO_GPLEV0)" is a premise in three
+	// separate arguments in this investigation and has never been measured
+	// once. Run at mount, outside the emulation loop, so it costs the loop
+	// nothing.
+	//   0 = GPLEV0 read, result used immediately
+	//   1 = the same ALU filler with no read at all, as the baseline
+	//   2 = GPLEV0 read with the filler between issue and use
+	//   3 = ARM_SYSTIMER_CLO read, result used immediately
+	// If 2 comes out near max(0,1) rather than near 0+1, the A53 keeps the
+	// Device load in flight and a second bus sample could be issued early and
+	// consumed late for almost nothing - which would end the budget problem.
+	static u32 diagReadCost[4];
+#endif
+
+	static u32 lostCycles;
+	static u32 worstLostUs;
+	// ARM clock in Hz as the firmware reported it at boot. The cycles-per-loop
+	// figures below mean nothing without it.
+	static u32 armClockHz;
+	// Count and worst-case say nothing about shape, and shape is what decides
+	// this: thousands of one-microsecond slips is a different fault from a
+	// handful of thirteen-microsecond stalls. Bucket by overrun size, and
+	// count every iteration so the rate can be stated as a fraction rather
+	// than as a bare million.
+	static u32 lostHist[16];
+	// u64, not u32: at one increment per emulated microsecond a 32 bit counter
+	// wraps after 71 minutes 35 seconds, and sectionCycles is already u64 - so
+	// past that point the divisor restarts while the dividend keeps going and
+	// every cycles/loop average and the overrun rate turn to nonsense, quietly.
+	// A GDOS64 installation plus a few GEOS tests passes an hour without
+	// trying, and this counter is the denominator of the whole acceptance test.
+	static u64 loopIterations;
+
+	// Where the microsecond actually goes. Skipping the two redundant GPIO
+	// writes moved the overrun rate from 63 to 62 per mille, i.e. nowhere, so
+	// the cost is elsewhere and guessing again would be a fourth wrong guess.
+	// The ARM cycle counter is the only clock fine enough to see inside a body
+	// that is shorter than one tick of the system timer; performance.c has the
+	// code to enable it and nothing in the tree ever called it.
+	//   0 = reading the IEC lines   1 = two CPU cycles plus VIA/RTC update
+	//   2 = driving the IEC lines   3 = LEDs, buttons, idle-flush check
+	static u64 sectionCycles[4];
+
+	static u32 scsiBusReads;
+	static u32 scsiBusMismatches;
+	static u8 scsiBusMismatchXor;
+	static u8 scsiBusMismatchDdr;
 
 	// Memory bus (called by the CPU on every cycle).
 	u8 Read(u16 address);
@@ -176,7 +262,13 @@ private:
 	Interrupt via10IRQ;
 
 	u8 forcedDeviceID;
+	unsigned preloadMB;
 	unsigned headPosition;
+
+	// How many 2MHz cycles between RTC top-ups - half a second, comfortably
+	// inside the 71.6 minute wrap of the microsecond counter it works from.
+	static const u32 RTC_TICK_CYCLES = 1000000;
+	u32 rtcTickCountdown;
 
 	// Buttons pressed by the user right now.
 	bool buttonWP;

--- a/src/emulation/rtc72421.cpp
+++ b/src/emulation/rtc72421.cpp
@@ -47,7 +47,7 @@ RTC72421::RTC72421()
 
 void RTC72421::Reset()
 {
-	// Default power on time: Wednesday 2026-01-01 00:00:00
+	// Default power on time: Thursday 2026-01-01 00:00:00
 	// (HDOS or GEOS can set the correct time via the T-W commands.)
 	seconds = 0;
 	minutes = 0;

--- a/src/emulation/rtc72421.h
+++ b/src/emulation/rtc72421.h
@@ -46,8 +46,13 @@ public:
 	u8 Read(u8 address);
 	void Write(u8 address, u8 data);
 
+	// Bring the calendar up to date with the system timer. Reads and writes do
+	// this themselves; the caller also has to do it every so often, because the
+	// elapsed time is worked out from a 32 bit microsecond counter and a gap
+	// longer than its 71.6 minute wrap is indistinguishable from a short one.
+	void Tick();
+
 private:
-	void Tick();				// bring the calendar up to date with the system timer
 	void IncrementSecond();
 
 	u8 seconds, minutes, hours;	// binary, hours always kept in 24h form internally

--- a/src/emulation/scsi.cpp
+++ b/src/emulation/scsi.cpp
@@ -2,7 +2,7 @@
 //
 // SCSI disk (target) emulation.
 // Ported from VICE's scsi.c written by Roberto Muscedere, adapted to
-// FatFS backed image files with a write-through sector cache.
+// FatFS backed image files with a write-back sector cache.
 //
 // This file is part of Pi1541.
 //
@@ -21,6 +21,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include "scsi.h"
 #include "debug.h"
 #include "rpihardware.h"
@@ -29,36 +30,50 @@
 #define MAXLUNS 8
 
 ///////////////////////////////////////////////////////////////////////////////
-// ScsiImage - a FatFS backed hard disk image with a write-through cache.
+// ScsiImage - a FatFS backed hard disk image with a write-back cache.
 ///////////////////////////////////////////////////////////////////////////////
 
 u8* ScsiImage::cachePool = 0;
 ScsiImage::CacheSlot* ScsiImage::cacheSlots = 0;
 u32 ScsiImage::numCacheSlots = 0;
-u8 ScsiImage::nextImageId = 0;
 
 void ScsiImage::InitCache(u32 sizeInBytes)
 {
 	if (cachePool)
 		return;
 
-	numCacheSlots = sizeInBytes >> CACHE_CHUNK_SHIFT;
-	if (numCacheSlots < 16)
-		numCacheSlots = 16;
+	u32 slots = sizeInBytes >> CACHE_CHUNK_SHIFT;
+	if (slots < 16)
+		slots = 16;
 
-	cachePool = (u8*)malloc(numCacheSlots * CACHE_CHUNK_SIZE);
-	cacheSlots = (CacheSlot*)malloc(numCacheSlots * sizeof(CacheSlot));
-
-	if (!cachePool || !cacheSlots)
+	// Settle for a smaller cache rather than none: with numCacheSlots at zero
+	// every single access goes to the card synchronously, which is exactly the
+	// stall the cache exists to avoid.
+	for (;;)
 	{
-		DEBUG_LOG("SCSI: failed to allocate %u byte cache\r\n", numCacheSlots * CACHE_CHUNK_SIZE);
+		cachePool = (u8*)malloc(slots * CACHE_CHUNK_SIZE);
+		cacheSlots = (CacheSlot*)malloc(slots * sizeof(CacheSlot));
+		if (cachePool && cacheSlots)
+			break;
+
 		free(cachePool);
 		free(cacheSlots);
 		cachePool = 0;
 		cacheSlots = 0;
-		numCacheSlots = 0;
-		return;
+
+		if (slots <= 16)
+		{
+			DEBUG_LOG("SCSI: failed to allocate %u byte cache\r\n", slots * CACHE_CHUNK_SIZE);
+			numCacheSlots = 0;
+			return;
+		}
+
+		slots >>= 1;
+		if (slots < 16)
+			slots = 16;
 	}
+
+	numCacheSlots = slots;
 
 	for (u32 i = 0; i < numCacheSlots; ++i)
 	{
@@ -88,7 +103,24 @@ bool ScsiImage::Attach(const char* filename, bool readOnly)
 	name[sizeof(name) - 1] = 0;
 	attached = true;
 	needSync = false;
-	imageId = nextImageId++;
+	// Take the lowest id no attached image is using, rather than counting up
+	// forever: the id is only 8 bits and it picks cache slots, so once it wraps
+	// two live images would answer to the same one and read each other's
+	// chunks - or get flushed through the wrong file handle. At most
+	// SCSI_MAX_DISKS are ever attached, so a free id always exists.
+	imageId = 0;
+	for (u32 i = 0; i < numAttachedImages; )
+	{
+		if (attachedImages[i]->imageId == imageId)
+		{
+			imageId++;
+			i = 0;		// start over; the new id may collide with an earlier one
+		}
+		else
+		{
+			i++;
+		}
+	}
 	if (numAttachedImages < 64)
 		attachedImages[numAttachedImages++] = this;
 
@@ -107,7 +139,16 @@ void ScsiImage::Detach()
 {
 	if (attached)
 	{
-		Sync(true);
+		// Retry before giving up. Below, every slot belonging to this image is
+		// invalidated, so whatever is still dirty at that point is gone - and
+		// this is the last chance to notice. A transient write error is worth
+		// a second attempt; a full card is not going to improve, but it is
+		// going to be reported instead of swallowed.
+		for (u32 attempt = 0; attempt < 3 && !Sync(true); ++attempt)
+			;
+		if (needSync)
+			unflushedSectors += DirtySectorCount();
+
 		f_close(&file);
 		attached = false;
 
@@ -122,6 +163,11 @@ void ScsiImage::Detach()
 		}
 		sizeInSectors = 0;
 
+		// Release the pinned region before invalidating, or the slots it covers
+		// would stay reserved for an image that is no longer here.
+		if (pinnedChunks && pinnedImage == imageId)
+			pinnedChunks = 0;
+
 		for (u32 i = 0; i < numCacheSlots; ++i)
 		{
 			if (cacheSlots[i].valid && cacheSlots[i].image == imageId)
@@ -130,10 +176,10 @@ void ScsiImage::Detach()
 	}
 }
 
-void ScsiImage::Sync(bool force)
+bool ScsiImage::Sync(bool force)
 {
 	if (!attached || !needSync)
-		return;
+		return true;
 
 	// Only ever flush on demand. This used to run on a timer from the SCSI
 	// state machine returning to BUSFREE - which is between commands, exactly
@@ -142,11 +188,32 @@ void ScsiImage::Sync(bool force)
 	// wait, so the drive vanished mid-transfer. Flushing now happens only when
 	// the bus has gone quiet (FlushIdle) or on detach.
 	if (!force)
-		return;
+		return true;
 
-	FlushAllDirty();
+	// needSync stays set when this fails, so the next quiet moment - or the
+	// next Detach - tries again rather than the data quietly ceasing to exist.
+	// No bound here: detach has to finish, and by then the bus is done with us.
+	if (FlushAllDirty(0, 0) != FLUSH_DONE)
+		return false;
+
 	f_sync(&file);
 	needSync = false;
+	return true;
+}
+
+// Sectors still marked dirty across every slot of this image: what would be
+// thrown away if the slots were invalidated right now.
+u32 ScsiImage::DirtySectorCount()
+{
+	u32 n = 0;
+	for (u32 i = 0; i < numCacheSlots; ++i)
+	{
+		if (!(cacheSlots[i].valid && cacheSlots[i].image == imageId))
+			continue;
+		u8 m = cacheSlots[i].dirtyMask;
+		while (m) { n += (m & 1); m >>= 1; }
+	}
+	return n;
 }
 
 ScsiImage::CacheSlot* ScsiImage::FindSlot(u32 chunkIndex, bool allocate)
@@ -154,9 +221,20 @@ ScsiImage::CacheSlot* ScsiImage::FindSlot(u32 chunkIndex, bool allocate)
 	if (!cacheSlots)
 		return 0;
 
-	// 2-way set associative on a multiplicative hash.
-	u32 hash = (chunkIndex * 2654435761u + imageId * 40503u) % numCacheSlots;
-	u32 hash2 = (hash + 1) % numCacheSlots;
+	// Pinned region. Chunk N of the preloaded image lives in slot N and nowhere
+	// else, so nothing can ever evict it and no access to it can reach the
+	// card. A hash would not do: 4096 chunks scattered over 16384 slots two
+	// ways deep still collide often enough to leave a few hundred holes, and
+	// one hole in the wrong place is the whole bug.
+	if (pinnedChunks && imageId == pinnedImage && chunkIndex < pinnedChunks)
+		return &cacheSlots[chunkIndex];
+
+	// 2-way set associative on a multiplicative hash, over whatever is left.
+	u32 span = numCacheSlots - pinnedChunks;
+	if (!span)
+		return 0;
+	u32 hash = pinnedChunks + (chunkIndex * 2654435761u + imageId * 40503u) % span;
+	u32 hash2 = pinnedChunks + (hash + 1 - pinnedChunks) % span;
 
 	CacheSlot* slot = &cacheSlots[hash];
 	if (slot->valid && slot->image == imageId && slot->chunkIndex == chunkIndex)
@@ -168,17 +246,39 @@ ScsiImage::CacheSlot* ScsiImage::FindSlot(u32 chunkIndex, bool allocate)
 	if (!allocate)
 		return 0;
 
-	// Prefer replacing an invalid slot.
-	CacheSlot* victim = slot->valid ? (slot2->valid ? slot : slot2) : slot;
+	// Prefer an unused slot, then a clean one. Evicting a dirty chunk means a
+	// synchronous write to the card from whatever called us - including
+	// WriteSector, which must not go near it while the computer is polling for
+	// status. Only pick a dirty victim when the whole set is dirty.
+	CacheSlot* victim;
+	if (!slot->valid)
+		victim = slot;
+	else if (!slot2->valid)
+		victim = slot2;
+	else if (!slot->dirtyMask)
+		victim = slot;
+	else
+		victim = slot2;
 
 	// Never drop writes on the floor. The chunk being evicted may belong to
 	// another image, so flush it through whoever owns it.
+	//
+	// This is the one path that can still put an SD write in the middle of a
+	// WriteSector, contradicting the promise made there. It only happens when
+	// every way of the set is dirty, which in turn only happens when FlushIdle
+	// has not had a quiet moment to run - exactly the case during a long
+	// transfer. Count it so it stops being guesswork.
 	if (victim->valid && victim->dirtyMask)
 	{
+		dirtyEvictions++;
 		ScsiImage* owner = ImageById(victim->image);
-		if (owner)
-			owner->FlushChunk(*victim);
-		victim->dirtyMask = 0;
+		if (!owner || owner->FlushChunk(*victim) != 0)
+		{
+			// The card would not take it. Leave the chunk dirty so a later
+			// flush can try again and hand the caller nothing, which sends it
+			// straight to the file - losing the sectors here would be silent.
+			return 0;
+		}
 	}
 
 	victim->valid = 0;
@@ -193,19 +293,336 @@ ScsiImage* ScsiImage::attachedImages[64] = { 0 };
 u32 ScsiImage::numAttachedImages = 0;
 u32 ScsiImage::worstStallMicros = 0;
 u32 ScsiImage::accessCounter = 0;
+u32 ScsiImage::dirtyEvictions = 0;
+u32 ScsiImage::cacheReadHits = 0;
+u32 ScsiImage::cacheReadMisses = 0;
+u32 ScsiImage::dirtyChunkReads = 0;
+u32 ScsiImage::dirtyChunkPartialFills = 0;
 
-void ScsiImage::FlushIdle()
+#if PICMD_ACCESS_FORENSICS
+ScsiImage::AccessLogEntry ScsiImage::accessLog[ScsiImage::ACCESS_LOG_ENTRIES];
+u32 ScsiImage::accessLogCount = 0;
+#endif
+u32 ScsiImage::maxLbaWritten = 0;
+
+void ScsiImage::ResetCounters()
+{
+	worstStallMicros = 0;
+	dirtyEvictions = 0;
+	cacheReadHits = 0;
+	cacheReadMisses = 0;
+	dirtyChunkReads = 0;
+	dirtyChunkPartialFills = 0;
+	bitRotWrites = 0;
+	bitRotBytes = 0;
+	bitRotFirstLba = 0;
+	bitRotMask = 0;
+#if PICMD_ACCESS_FORENSICS
+	accessLogCount = 0;
+#endif
+	maxLbaWritten = 0;
+#if PICMD_ACCESS_FORENSICS
+	writeLogCount = 0;
+#endif
+}
+
+u32 ScsiImage::unflushedSectors = 0;
+u32 ScsiImage::bitRotWrites = 0;
+u32 ScsiImage::bitRotBytes = 0;
+u32 ScsiImage::bitRotFirstLba = 0;
+u8 ScsiImage::bitRotMask = 0;
+
+u32 ScsiImage::pinnedChunks = 0;
+u8 ScsiImage::pinnedImage = 0;
+
+// Read the front of the image into slots 0..n-1 and pin it there. Called at
+// mount, with the bus quiet and nobody waiting on us, so the cost of going to
+// the card is paid once instead of arriving in the middle of a transfer.
+//
+// Every chunk this covers is one fewer 35ms freeze, and a freeze is what makes
+// the computer decide the drive is not there.
+u32 ScsiImage::PreloadCache(u32 maxBytes, volatile u32* progressSectors, volatile u32* totalSectors)
+{
+	if (!cacheSlots || !attached || !maxBytes)
+		return 0;
+
+	// Leave a quarter of the cache hashed, so other images and anything past
+	// the preloaded region still have somewhere to go.
+	u32 chunks = maxBytes >> CACHE_CHUNK_SHIFT;
+	u32 imageChunks = (sizeInSectors + SECTORS_PER_CHUNK - 1) / SECTORS_PER_CHUNK;
+	u32 limit = numCacheSlots - (numCacheSlots >> 2);
+	if (chunks > imageChunks)
+		chunks = imageChunks;
+	if (chunks > limit)
+		chunks = limit;
+	if (!chunks)
+		return 0;
+
+	// Claim the region before filling it, so FindSlot hands back slot N for
+	// chunk N as each one lands.
+	pinnedChunks = chunks;
+	pinnedImage = imageId;
+
+	if (totalSectors)
+		*totalSectors = chunks * SECTORS_PER_CHUNK;
+
+	// Chunk N is pinned to slot N and slot N's data is cachePool + N*4K, so the
+	// whole region is contiguous in memory as well as in the file. Read it in
+	// big blocks: chunk at a time meant thousands of separate seeks and reads,
+	// which at this card's latency turned the mount into minutes.
+	const u32 BLOCK = 1u << 20;
+	u32 wanted = chunks * CACHE_CHUNK_SIZE;
+	u32 done = 0;
+
+	if (f_lseek(&file, 0) != FR_OK)
+	{
+		pinnedChunks = 0;
+		if (totalSectors)
+			*totalSectors = 0;
+		return 0;
+	}
+
+	while (done < wanted)
+	{
+		u32 ask = wanted - done;
+		if (ask > BLOCK)
+			ask = BLOCK;
+
+		UINT got = 0;
+		if (f_read(&file, cachePool + done, ask, &got) != FR_OK)
+			break;
+
+		done += got;
+		if (progressSectors)
+			*progressSectors = done / SECTOR_SIZE;
+
+		if (got < ask)
+			break;			// end of file
+	}
+
+	// Anything the file did not cover reads as zeros, the same contract
+	// FillChunk honours past EOF.
+	if (done < wanted)
+		memset(cachePool + done, 0, wanted - done);
+
+	u32 loaded = done >> CACHE_CHUNK_SHIFT;
+
+	for (u32 i = 0; i < chunks; ++i)
+	{
+		CacheSlot& slot = cacheSlots[i];
+		slot.image = imageId;
+		slot.chunkIndex = i;
+		slot.dirtyMask = 0;
+		// Only whole chunks that actually arrived are presented as valid. A
+		// partial tail is left cold so the first read fills it the usual way
+		// rather than serving a half read chunk as if it were real.
+		if (i < loaded)
+		{
+			slot.valid = 1;
+			slot.validMask = 0xff;
+		}
+		else
+		{
+			slot.valid = 0;
+			slot.validMask = 0;
+		}
+	}
+
+	if (totalSectors)
+		*totalSectors = 0;
+
+	DEBUG_LOG("SCSI: preloaded %u of %u chunks (%u KB pinned)\r\n",
+		loaded, chunks, (chunks * CACHE_CHUNK_SIZE) >> 10);
+	return loaded;
+}
+
+#if PICMD_ACCESS_FORENSICS
+u8 ScsiImage::writeLogData[ScsiImage::WRITE_LOG_ENTRIES][ScsiImage::SECTOR_SIZE];
+u32 ScsiImage::writeLogLba[ScsiImage::WRITE_LOG_ENTRIES];
+u32 ScsiImage::writeLogSeq[ScsiImage::WRITE_LOG_ENTRIES];
+u32 ScsiImage::writeLogCount = 0;
+#endif
+
+// snprintf returns what it would have written, not what it did. Handing that
+// to f_write walks off the end of the buffer.
+static UINT Clamp(int produced, size_t capacity)
+{
+	if (produced < 0)
+		return 0;
+	return (UINT)((size_t)produced < capacity ? (size_t)produced : capacity - 1);
+}
+
+#if PICMD_ACCESS_FORENSICS
+// Every write as it was handed to us, payload and all. Dumped on eject next to
+// the address log, so the two can be lined up by sequence number.
+bool ScsiImage::DumpWriteLog(const char* prefix)
+{
+	if (writeLogCount == 0)
+		return false;
+
+	char filename[64];
+	FILINFO fno;
+	unsigned serial = 0;
+	for (;; ++serial)
+	{
+		if (serial > 99)
+			return false;
+		snprintf(filename, sizeof(filename), "%s%02u.LOG", prefix, serial);
+		if (f_stat(filename, &fno) != FR_OK)
+			break;
+	}
+
+	FIL fp;
+	if (f_open(&fp, filename, FA_CREATE_ALWAYS | FA_WRITE) != FR_OK)
+		return false;
+
+	char line[160];
+	UINT written;
+	bool wrapped = writeLogCount > WRITE_LOG_ENTRIES;
+	u32 held = wrapped ? WRITE_LOG_ENTRIES : writeLogCount;
+	u32 first = wrapped ? writeLogCount - WRITE_LOG_ENTRIES : 0;
+
+	int n = snprintf(line, sizeof(line), "# %u writes, %u held%s\r\n",
+		writeLogCount, held, wrapped ? " (wrapped, oldest lost)" : "");
+	f_write(&fp, line, Clamp(n, sizeof(line)), &written);
+
+	for (u32 i = 0; i < held; ++i)
+	{
+		u32 slot = (first + i) % WRITE_LOG_ENTRIES;
+		n = snprintf(line, sizeof(line), "W %u lba %u\r\n",
+			writeLogSeq[slot], writeLogLba[slot]);
+		if (f_write(&fp, line, Clamp(n, sizeof(line)), &written) != FR_OK)
+			break;
+
+		const u8* d = writeLogData[slot];
+		for (u32 off = 0; off < SECTOR_SIZE; off += 32)
+		{
+			n = snprintf(line, sizeof(line), "%03x:", off);
+			for (u32 j = 0; j < 32; ++j)
+				n += snprintf(line + n, sizeof(line) - n, "%02x", d[off + j]);
+			n += snprintf(line + n, sizeof(line) - n, "\r\n");
+			if (f_write(&fp, line, Clamp(n, sizeof(line)), &written) != FR_OK)
+			{
+				f_close(&fp);
+				return false;
+			}
+		}
+	}
+
+	f_close(&fp);
+	return true;
+}
+#endif
+
+#if PICMD_ACCESS_FORENSICS
+void ScsiImage::LogAccess(u32 lba, u8 op, u8 result)
+{
+	accessLog[accessLogCount % ACCESS_LOG_ENTRIES].lba = lba;
+	accessLog[accessLogCount % ACCESS_LOG_ENTRIES].op = op;
+	accessLog[accessLogCount % ACCESS_LOG_ENTRIES].image = imageId;
+	accessLog[accessLogCount % ACCESS_LOG_ENTRIES].result = result;
+	accessLogCount++;
+
+	if (op == 'W' && result == 0 && lba > maxLbaWritten)
+		maxLbaWritten = lba;
+}
+#endif
+
+#if PICMD_ACCESS_FORENSICS
+// Write the log out as text. Only ever called from eject, when the bus is
+// already done with us and a slow card costs nothing.
+//
+// The name gets a two digit serial because eject is also how you get back to
+// the file browser: going back in to look at the result of a run and coming
+// out again would otherwise overwrite the run you wanted to keep.
+bool ScsiImage::DumpAccessLog(const char* prefix)
+{
+	if (accessLogCount == 0)
+		return false;
+
+	char filename[64];
+	FILINFO fno;
+	unsigned serial = 0;
+	for (;; ++serial)
+	{
+		if (serial > 99)
+			return false;		// 100 runs without emptying the card; give up
+		snprintf(filename, sizeof(filename), "%s%02u.LOG", prefix, serial);
+		if (f_stat(filename, &fno) != FR_OK)
+			break;				// free name
+	}
+
+	FIL fp;
+	if (f_open(&fp, filename, FA_CREATE_ALWAYS | FA_WRITE) != FR_OK)
+		return false;
+
+	char line[128];
+	UINT written;
+	bool wrapped = accessLogCount > ACCESS_LOG_ENTRIES;
+	u32 held = wrapped ? ACCESS_LOG_ENTRIES : accessLogCount;
+	u32 first = wrapped ? accessLogCount - ACCESS_LOG_ENTRIES : 0;
+
+	// Two lines, written separately: together they overrun a 128 byte buffer,
+	// and snprintf reports the length it wanted rather than the length it
+	// produced - so handing that straight to f_write read off the end of the
+	// array and put rubbish in the header.
+	int n = snprintf(line, sizeof(line),
+		"# seq op lba image result   (op: R cached read, W write, U uncached read)\r\n");
+	f_write(&fp, line, Clamp(n, sizeof(line)), &written);
+	n = snprintf(line, sizeof(line), "# %u accesses, %u held%s, max lba written %u\r\n",
+		accessLogCount, held, wrapped ? " (wrapped, oldest lost)" : "", maxLbaWritten);
+	f_write(&fp, line, Clamp(n, sizeof(line)), &written);
+
+	for (u32 i = 0; i < held; ++i)
+	{
+		const AccessLogEntry& e = accessLog[(first + i) % ACCESS_LOG_ENTRIES];
+		n = snprintf(line, sizeof(line), "%u %c %u %u %u\r\n",
+			first + i, (char)e.op, e.lba, (unsigned)e.image, (unsigned)e.result);
+		UINT len = Clamp(n, sizeof(line));
+		if (f_write(&fp, line, len, &written) != FR_OK || written != len)
+		{
+			f_close(&fp);
+			return false;
+		}
+	}
+
+	f_close(&fp);
+	return true;
+}
+#endif
+
+// Returns true only when there is nothing left owed anywhere. False means come
+// back - the bus asked for the drive, a write failed, or the per-visit bound
+// was reached - and needSync is still set on whatever is left.
+ScsiImage::FlushResult ScsiImage::FlushIdle(bool (*abort)())
 {
 	for (u32 i = 0; i < numAttachedImages; ++i)
 	{
 		ScsiImage* img = attachedImages[i];
 		if (img && img->attached && img->needSync)
 		{
-			img->FlushAllDirty();
+			// Stop the moment the bus wants us again rather than finishing the
+			// backlog regardless. f_sync only once there is nothing left, or it
+			// would be paying for metadata on every partial drain.
+			FlushResult r = img->FlushAllDirty(abort, IDLE_FLUSH_CHUNKS);
+			if (r != FLUSH_DONE)
+				return r;
 			f_sync(&img->file);
 			img->needSync = false;
 		}
 	}
+	return FLUSH_DONE;
+}
+
+u32 ScsiImage::DirtyChunkCount()
+{
+	u32 n = 0;
+	for (u32 i = 0; i < numCacheSlots; ++i)
+	{
+		if (cacheSlots[i].valid && cacheSlots[i].dirtyMask)
+			n++;
+	}
+	return n;
 }
 
 ScsiImage* ScsiImage::ImageById(u8 id)
@@ -251,14 +668,20 @@ int ScsiImage::ReadSector(u32 lba, u8* buffer)
 {
 	accessCounter++;
 	if (!attached)
+	{
+		LogAccess(lba, 'R', 1);
 		return -1;
+	}
 
 	if (lba >= sizeInSectors)
 	{
 		// Reads beyond the end of the image return zeros (matches VICE).
+		LogAccess(lba, 'R', 1);
 		memset(buffer, 0, SECTOR_SIZE);
 		return 0;
 	}
+
+	LogAccess(lba, 'R', 0);
 
 	u32 chunkIndex = lba / SECTORS_PER_CHUNK;
 	u32 sectorInChunk = lba % SECTORS_PER_CHUNK;
@@ -267,7 +690,9 @@ int ScsiImage::ReadSector(u32 lba, u8* buffer)
 	CacheSlot* slot = FindSlot(chunkIndex, true);
 	if (!slot)
 	{
-		// No cache; read straight through.
+		// No cache, or the set was full of chunks the card would not take.
+		// Either way, read straight through.
+		cacheReadMisses++;
 		UINT bytesRead = 0;
 		u32 t0 = read32(ARM_SYSTIMER_CLO);
 		if (f_lseek(&file, (u64)lba << 9) != FR_OK)
@@ -280,8 +705,18 @@ int ScsiImage::ReadSector(u32 lba, u8* buffer)
 		return 0;
 	}
 
-	if (!(slot->validMask & bit))
+	// Sampled before anything below can clear it. Note FillChunk only ever runs
+	// with dirtyMask already zero, so it cannot race this.
+	if (slot->dirtyMask)
+		dirtyChunkReads++;
+
+	if (slot->validMask & bit)
 	{
+		cacheReadHits++;
+	}
+	else
+	{
+		cacheReadMisses++;
 		if (slot->dirtyMask == 0)
 		{
 			// Nothing to lose, so pull the whole chunk in and keep the
@@ -296,6 +731,7 @@ int ScsiImage::ReadSector(u32 lba, u8* buffer)
 		{
 			// Part of this chunk is written but not yet on the card, so a
 			// whole-chunk read would clobber it. Fetch just this sector.
+			dirtyChunkPartialFills++;
 			UINT bytesRead = 0;
 			u32 t0 = read32(ARM_SYSTIMER_CLO);
 			if (f_lseek(&file, (u64)lba << 9) != FR_OK)
@@ -319,20 +755,29 @@ int ScsiImage::ReadSectorUncached(u32 lba, u8* buffer)
 {
 	accessCounter++;
 	if (!attached)
+	{
+		LogAccess(lba, 'U', 1);
 		return -1;
+	}
 
 	if (lba >= sizeInSectors)
 	{
+		LogAccess(lba, 'U', 1);
 		memset(buffer, 0, SECTOR_SIZE);
 		return 0;
 	}
 
+	LogAccess(lba, 'U', 0);
+
 	// If the sector happens to be cached, take it from there - but never fill
-	// the cache on its account.
+	// the cache on its account. A slot being valid only says the chunk is
+	// allocated: a write leaves the other seven sectors of it holding whatever
+	// was there before, so the per sector bit has to be checked as well.
+	u32 sectorInChunk = lba % SECTORS_PER_CHUNK;
 	CacheSlot* slot = FindSlot(lba / SECTORS_PER_CHUNK, false);
-	if (slot && slot->valid)
+	if (slot && slot->valid && (slot->validMask & (1 << sectorInChunk)))
 	{
-		memcpy(buffer, slot->data + (lba % SECTORS_PER_CHUNK) * SECTOR_SIZE, SECTOR_SIZE);
+		memcpy(buffer, slot->data + sectorInChunk * SECTOR_SIZE, SECTOR_SIZE);
 		return 0;
 	}
 
@@ -348,10 +793,30 @@ int ScsiImage::WriteSector(u32 lba, const u8* buffer)
 {
 	accessCounter++;
 	if (!attached || readOnly)
+	{
+		LogAccess(lba, 'W', 1);
 		return -1;
+	}
 
 	if (lba >= sizeInSectors)
+	{
+		LogAccess(lba, 'W', 1);
 		return -1;
+	}
+
+	LogAccess(lba, 'W', 0);
+
+#if PICMD_WRITE_FORENSICS
+	// Keep the payload too. accessLogCount has just been bumped past this
+	// access, so seq-1 is the entry in the address log that matches.
+	{
+		u32 slot = writeLogCount % WRITE_LOG_ENTRIES;
+		memcpy(writeLogData[slot], buffer, SECTOR_SIZE);
+		writeLogLba[slot] = lba;
+		writeLogSeq[slot] = accessLogCount - 1;
+		writeLogCount++;
+	}
+#endif
 
 	u32 chunkIndex = lba / SECTORS_PER_CHUNK;
 	u32 sectorInChunk = lba % SECTORS_PER_CHUNK;
@@ -368,6 +833,38 @@ int ScsiImage::WriteSector(u32 lba, const u8* buffer)
 			slot->validMask = 0;
 			slot->dirtyMask = 0;
 		}
+#if PICMD_WRITE_FORENSICS
+		// Before it is overwritten, ask what changed. See BitRotWrites in the
+		// header: bytes that only ever gain bits 0 and 1 are the corruption,
+		// and this is the one place the before and after are both to hand.
+		if (slot->validMask & (1 << sectorInChunk))
+		{
+			const u8* was = slot->data + sectorInChunk * SECTOR_SIZE;
+			u32 differing = 0;
+			u32 gainedLowBits = 0;
+			u8 gained = 0;
+			for (u32 i = 0; i < SECTOR_SIZE; i++)
+			{
+				if (was[i] == buffer[i])
+					continue;
+				differing++;
+				if ((u8)(buffer[i] & 0xfc) == was[i])
+				{
+					gainedLowBits++;
+					gained |= (u8)(buffer[i] ^ was[i]);
+				}
+			}
+			if (differing >= 3 && gainedLowBits == differing)
+			{
+				if (!bitRotWrites)
+					bitRotFirstLba = lba;
+				bitRotWrites++;
+				bitRotBytes += gainedLowBits;
+				bitRotMask |= gained;
+			}
+		}
+#endif
+
 		memcpy(slot->data + sectorInChunk * SECTOR_SIZE, buffer, SECTOR_SIZE);
 		slot->validMask |= (u8)(1 << sectorInChunk);
 		slot->dirtyMask |= (u8)(1 << sectorInChunk);
@@ -408,7 +905,11 @@ int ScsiImage::FlushChunk(CacheSlot& slot)
 		u64 offset = ((u64)slot.chunkIndex << CACHE_CHUNK_SHIFT) + (u64)s * SECTOR_SIZE;
 		if (f_lseek(&file, offset) != FR_OK)
 			return -1;
-		if (f_write(&file, slot.data + s * SECTOR_SIZE, run * SECTOR_SIZE, &written) != FR_OK)
+		// A short write is not an error as far as FatFS is concerned - a full
+		// card returns FR_OK having written less than asked. Treat it as one,
+		// or the caller clears dirtyMask on sectors that never reached the SD.
+		if (f_write(&file, slot.data + s * SECTOR_SIZE, run * SECTOR_SIZE, &written) != FR_OK
+			|| written != run * SECTOR_SIZE)
 			return -1;
 		NoteStall(t0);
 		s += run;
@@ -418,13 +919,45 @@ int ScsiImage::FlushChunk(CacheSlot& slot)
 	return 0;
 }
 
-void ScsiImage::FlushAllDirty()
+ScsiImage::FlushResult ScsiImage::FlushAllDirty(bool (*abort)(), u32 maxChunks)
 {
+	u32 done = 0;
+
 	for (u32 i = 0; i < numCacheSlots; ++i)
 	{
-		if (cacheSlots[i].valid && cacheSlots[i].dirtyMask && cacheSlots[i].image == imageId)
-			FlushChunk(cacheSlots[i]);
+		if (!(cacheSlots[i].valid && cacheSlots[i].dirtyMask && cacheSlots[i].image == imageId))
+			continue;
+		// Asked before committing to the write, not after: once FlushChunk is
+		// under way the CPU is frozen for as long as the card takes.
+		//
+		// And asked BEFORE the bound below, not after. The other order looks
+		// harmless and is not: with a bound of one chunk the function would
+		// return at the second dirty slot without ever evaluating abort, so
+		// the callback would become a thing that cannot fire - which is the
+		// failure mode this project has documented three times.
+		if (abort && abort())
+			return FLUSH_STOPPED;
+
+		// Stop after maxChunks and let the caller come back. The emulated CPU
+		// is frozen for every card write in this loop, and unbounded that came
+		// to 48 milliseconds in one go on a GEOS installation - measured, the
+		// worst overrun in PICMD-LST37.LOG. A bound turns one long freeze into
+		// several short ones with the loop running in between. maxChunks == 0
+		// means no bound, for detach, where finishing matters more than
+		// latency.
+		if (maxChunks && done >= maxChunks)
+			return FLUSH_MORE;
+		// FlushChunk leaves dirtyMask set on purpose when the write did not
+		// land, so the caller can come back for it. Dropping the return here
+		// turned that into "we tried once and then forgot": Sync cleared
+		// needSync on the strength of a true that meant nothing, and Detach
+		// invalidated the slots underneath. A full or failing card lost the
+		// user's sectors without a word.
+		if (FlushChunk(cacheSlots[i]) != 0)
+			return FLUSH_STOPPED;
+		++done;
 	}
+	return FLUSH_DONE;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -723,7 +1256,11 @@ void scsi_process_ack(scsi_context_t* context)
 		{
 			context->io = 0;
 			context->cd = 0;
-			context->data_buf[context->seq] = data;
+			// seq is the index, and it is bumped past the end deliberately to
+			// mark a full buffer - and REASSIGN BLOCKS below parks it there
+			// outright - so it has to be checked before it is used, not after.
+			if (context->seq < sizeof(context->data_buf))
+				context->data_buf[context->seq] = data;
 			context->seq++;
 			if (context->seq >= context->data_max)
 			{
@@ -792,9 +1329,9 @@ void scsi_process_ack(scsi_context_t* context)
 							(context->data_buf[1] << 16) |
 							(context->data_buf[2] << 8) |
 							(context->data_buf[3])) + 4;
-						if (context->seq > 512)
+						if (context->seq >= sizeof(context->data_buf))
 						{
-							context->seq = 512;
+							context->seq = sizeof(context->data_buf) - 1;
 						}
 					}
 					else
@@ -1233,15 +1770,11 @@ void scsi_process_ack(scsi_context_t* context)
 	}
 
 out:
-	// Flush FatFS metadata whenever we return to the status phase after writes.
-	if (context->state == SCSI_STATE_BUSFREE)
-	{
-		for (int d = 0; d < SCSI_MAX_DISKS; ++d)
-		{
-			if (context->file[d])
-				context->file[d]->Sync();
-		}
-	}
+	// Nothing is flushed here on purpose. This used to sweep every image on the
+	// way back to BUSFREE, which is precisely when the computer polls us for
+	// status - see the note on ScsiImage::Sync. The sweep had in fact been dead
+	// for a while, because Sync() without force returns immediately; it is gone
+	// now so the next reader is not misled into thinking writes land here.
 	return;
 }
 

--- a/src/emulation/scsi.h
+++ b/src/emulation/scsi.h
@@ -2,7 +2,7 @@
 //
 // SCSI disk (target) emulation.
 // Ported from VICE's scsi.c/scsi.h written by Roberto Muscedere, adapted to
-// FatFS backed image files with a write-through sector cache.
+// FatFS backed image files with a write-back sector cache.
 //
 // This file is part of Pi1541.
 //
@@ -27,6 +27,25 @@
 
 struct scsi_context_s;
 
+// Write-path forensics: the payload ring and the bit-rot scan, both of which
+// live inside WriteSector and therefore run on the emulation thread, once per
+// 512 byte sector the computer writes.
+//
+// Off by default because they are not free, contrary to what the comment above
+// BitRotWrites used to claim. A 512 byte memcpy plus a 512 iteration compare
+// land on ONE iteration of a loop whose budget is 1.2us. PICMD-LST18.LOG, from
+// a GEOS installation, counts 745 + 1656 + 113 = 2514 overruns of three, four
+// and five microseconds, against 2515 sector writes in PICMD-WR00.LOG: one
+// apiece, no exceptions. The drive's deadline for the first symbol of a
+// transmitted byte is ten CPU cycles, 5us, and that symbol carries bits 0 and
+// 1 - the bits this scan exists to watch being set. So the instrumentation is
+// large enough to cause the fault it was written to catch, which is the same
+// trap D4 of the timing handoff already recorded once.
+//
+// Set to 1 for a run that needs the payload log or the live rot counter, and
+// read the resulting numbers knowing they were bought at that price.
+#define PICMD_WRITE_FORENSICS 0
+
 // A SCSI hard disk image backed by a FatFS file.
 //
 // Accesses go through a write-back cache of CACHE_CHUNK_SIZE chunks so that
@@ -44,7 +63,14 @@ public:
 	static const u32 CACHE_CHUNK_SIZE = 1 << CACHE_CHUNK_SHIFT;
 	static const u32 SECTORS_PER_CHUNK = CACHE_CHUNK_SIZE / SECTOR_SIZE;
 
-	ScsiImage() : attached(false), sizeInSectors(0), readOnly(false) {}
+	// Everything, not just the three that used to be here: the images live in a
+	// global today so .bss covers the rest, but an ScsiImage anywhere else
+	// would start with a garbage imageId and match other images' cache slots.
+	ScsiImage()
+		: attached(false), sizeInSectors(0), readOnly(false), needSync(false), imageId(0)
+	{
+		name[0] = 0;
+	}
 
 	bool Attach(const char* filename, bool readOnly);
 	void Detach();
@@ -71,18 +97,134 @@ public:
 	// left alone.
 	static u32 AccessCounter() { return accessCounter; }
 
+	// How many times a slot had to be taken from a chunk that still had
+	// unwritten sectors in it. Every one of those is a synchronous write to
+	// the card from inside ReadSector/WriteSector - the exact stall the cache
+	// is supposed to prevent. If this stays at zero the cache is coping; if it
+	// climbs during a transfer, that is where the drive is going deaf.
+	static u32 DirtyEvictions() { return dirtyEvictions; }
+	static void ResetDirtyEvictions() { dirtyEvictions = 0; }
+
+	// Read instrumentation, for telling a cache coherency fault from a plain
+	// slow card. Only ReadSector is counted; the whole disk scan deliberately
+	// goes round the cache and would swamp the numbers.
+	//
+	// cacheReadHits   - answered from a slot without touching the card.
+	// cacheReadMisses - had to go to the file.
+	// dirtyChunkReads - landed on a chunk still holding unflushed writes.
+	// dirtyChunkPartialFills - the subset of those that also had to pull a
+	//   sector off the card into that same chunk. This is the only path in the
+	//   cache that mixes what the card holds with writes that have not reached
+	//   it, so if a stale block is ever handed back this is where it comes
+	//   from. Zero here rules the cache out the way dirtyEvictions did.
+	static u32 CacheReadHits() { return cacheReadHits; }
+	static u32 CacheReadMisses() { return cacheReadMisses; }
+	static u32 DirtyChunkReads() { return dirtyChunkReads; }
+	static u32 DirtyChunkPartialFills() { return dirtyChunkPartialFills; }
+
+	// Bytes that gain bits 0 and 1 and nothing else between one write of a
+	// sector and the next. That is the signature of the corruption eating the
+	// BAM and directory sectors: never 0x01 alone, never 0x02 alone, always
+	// both, and only ever in sectors the drive reads, modifies and writes back
+	// itself. Caught here rather than by comparing image files afterwards, so
+	// the first event names its own LBA while the machine is still running.
+	//
+	// Only checked when the sector's old contents are already sitting in the
+	// cache, which is exactly the read-modify-write case - so this costs no
+	// card access and cannot add a stall. Three bytes is the floor: real
+	// events run to eleven or more, while a single byte flipping to a low bit
+	// is ordinary data (a block count, a link) and would be noise.
+	// Sectors the card refused and that were dropped when the image detached.
+	// Anything other than zero here is user data that did not survive.
+	static u32 UnflushedSectors() { return unflushedSectors; }
+
+	static u32 BitRotWrites() { return bitRotWrites; }
+	static u32 BitRotBytes() { return bitRotBytes; }
+	static u32 BitRotFirstLba() { return bitRotFirstLba; }
+	static u8 BitRotMask() { return bitRotMask; }
+
+	// Zero every counter above, plus the stall watermark and the access log.
+	// Called on mount so the figures describe what the computer went on to do
+	// rather than the whole disk scan that precedes it - the scan alone is
+	// imagesize/128 reads, which would fill the log before the computer has
+	// asked for anything.
+	static void ResetCounters();
+
+	// Every sector access in order, so the pattern around a failure can be
+	// read back afterwards. The contents are known good by now; what is not
+	// known is where they were going. Held in RAM and written out on eject,
+	// because going to the card while the bus is live is what breaks the
+	// drive.
+#if PICMD_ACCESS_FORENSICS
+	static u32 AccessLogCount() { return accessLogCount; }
+#endif
+	static u32 MaxLbaWritten() { return maxLbaWritten; }
+#if PICMD_ACCESS_FORENSICS
+	static bool DumpAccessLog(const char* prefix);
+#endif
+
+	// The addresses turned out not to be enough: the data lands in the right
+	// sectors and the file still comes out half its length, so what matters
+	// now is the bytes. Keeps the whole 512 byte payload of the last writes.
+#if PICMD_ACCESS_FORENSICS
+	static bool DumpWriteLog(const char* prefix);
+#endif
+
+	// Chunks written per visit to FlushIdle. Not "one card write": FlushChunk
+	// writes each contiguous run of dirty sectors separately, so a 4K chunk
+	// with an alternating dirtyMask costs up to four f_write calls. One chunk
+	// is still the smallest unit the flush can be built out of, and it is what
+	// an eviction already costs - FindSlot flushes a single dirty victim
+	// synchronously - so this bounds the idle drain to a freeze the drive
+	// already survives elsewhere. The caller comes straight back on the next
+	// slow tick while the bus stays quiet, so a backlog drains promptly but in
+	// slices the drive can answer ATN between.
+	static const u32 IDLE_FLUSH_CHUNKS = 1;
+
+	// Why the flush stopped. The three used to be one bool, which meant the
+	// caller could not tell "there is more, come straight back" from "the card
+	// said no" - and retrying a failed write every 256us instead of every half
+	// second is a real-time regression for nothing, since FatFS latches the
+	// error and the retry never reaches the card anyway.
+	enum FlushResult
+	{
+		FLUSH_DONE,		// nothing left owed
+		FLUSH_MORE,		// hit the per-visit bound; come back next slow tick
+		FLUSH_STOPPED	// the bus wants us, or a write failed; back off
+	};
+
 	// Flush every attached image. Only call this when the serial bus is quiet:
 	// it goes to the card, which freezes the emulated CPU, and a frozen CPU
 	// cannot answer ATN.
-	static void FlushIdle();
+	//
+	// abort is checked before each chunk - and before the per-visit bound, so
+	// that a bound of one does not turn it into a callback that can never
+	// fire. Whatever is left stays dirty and goes out at the next quiet
+	// moment, or at detach.
+	static FlushResult FlushIdle(bool (*abort)() = 0);
+
+	// How many chunks are written but not yet on the card. This is what would
+	// be lost by pulling the power, so it is worth being able to see it.
+	static u32 DirtyChunkCount();
 
 	// Flush dirty chunks and FatFS metadata. Does nothing unless forced -
 	// going to the card at an arbitrary moment is what broke the bus. Detach
 	// forces it; everything else waits for FlushIdle.
-	void Sync(bool force = false);
+	bool Sync(bool force = false);
+
+	// Read the front of the image into the cache and pin it, so that region
+	// never costs an SD access again. Call it at mount and nowhere else: it
+	// goes to the card for as long as it takes, which is only safe while the
+	// bus is quiet. progressSectors/totalSectors drive the on screen bar and
+	// may be null. Returns the number of chunks actually loaded.
+	u32 PreloadCache(u32 maxBytes, volatile u32* progressSectors, volatile u32* totalSectors);
+	static u32 PinnedKB() { return (pinnedChunks * CACHE_CHUNK_SIZE) >> 10; }
 
 	// The (global) cache used by all images.
 	static void InitCache(u32 sizeInBytes);
+	// How much cache was actually obtained. Zero means every access goes
+	// straight to the card, so it is worth showing at boot.
+	static u32 CacheSizeKB() { return (numCacheSlots * CACHE_CHUNK_SIZE) >> 10; }
 
 private:
 	FIL file;
@@ -92,6 +234,52 @@ private:
 	bool needSync;
 	static u32 worstStallMicros;
 	static u32 accessCounter;
+	static u32 dirtyEvictions;
+	static u32 cacheReadHits;
+	static u32 cacheReadMisses;
+	static u32 dirtyChunkReads;
+	static u32 dirtyChunkPartialFills;
+	static u32 unflushedSectors;
+	static u32 bitRotWrites;
+	static u32 bitRotBytes;
+	static u32 bitRotFirstLba;
+	static u8 bitRotMask;
+
+	// 16K entries at 8 bytes is 128KB of BSS, and covers a GEOS install with
+	// room to spare. If it ever wraps, accessLogCount says so and the dump
+	// prints the surviving tail in order.
+	static const u32 ACCESS_LOG_ENTRIES = 16384;
+	struct AccessLogEntry
+	{
+		u32 lba;
+		u8 op;			// 'R' cached read, 'W' write, 'U' uncached read
+		u8 image;
+		u8 result;		// 0 = accepted, 1 = refused (out of range, detached)
+		u8 pad;
+	};
+#if PICMD_ACCESS_FORENSICS
+	static AccessLogEntry accessLog[ACCESS_LOG_ENTRIES];
+	static u32 accessLogCount;		// total accesses, not entries held
+#endif
+	static u32 maxLbaWritten;
+#if PICMD_ACCESS_FORENSICS
+	void LogAccess(u32 lba, u8 op, u8 result);
+#else
+	// Compiled to nothing rather than removed from the call sites: the calls
+	// mark the three places an access enters the image, which is worth keeping
+	// visible even when nobody is recording them.
+	inline void LogAccess(u32, u8, u8) {}
+#endif
+
+	// 256 payloads of 512 bytes is 128KB, and covers every write a whole file
+	// copy makes with room over.
+	static const u32 WRITE_LOG_ENTRIES = 256;
+#if PICMD_ACCESS_FORENSICS
+	static u8 writeLogData[WRITE_LOG_ENTRIES][SECTOR_SIZE];
+	static u32 writeLogLba[WRITE_LOG_ENTRIES];
+	static u32 writeLogSeq[WRITE_LOG_ENTRIES];	// index into the access log
+	static u32 writeLogCount;
+#endif
 
 	char name[256];
 
@@ -113,7 +301,9 @@ private:
 	// Push one dirty chunk out to the card. Used when a slot is reused for
 	// something else, and by Sync.
 	int FlushChunk(CacheSlot& slot);
-	void FlushAllDirty();
+	u32 DirtySectorCount();
+	// maxChunks == 0 means unbounded.
+	FlushResult FlushAllDirty(bool (*abort)() = 0, u32 maxChunks = 0);
 	static void NoteStall(u32 startMicros);
 
 	// A chunk being evicted can belong to a different disk, so we need to get
@@ -125,7 +315,11 @@ private:
 	static u8* cachePool;
 	static CacheSlot* cacheSlots;
 	static u32 numCacheSlots;
-	static u8 nextImageId;
+
+	// Slots [0, pinnedChunks) belong to image pinnedImage, chunk N in slot N.
+	// The hash covers only what is left, so nothing can collide with them.
+	static u32 pinnedChunks;
+	static u8 pinnedImage;
 
 	u8 imageId;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -236,6 +236,12 @@ void InitialiseHardware()
 	{
 		MaxClk = mp->data.buffer_32[1];
 	}
+	// Keep it. Every budget argument in this investigation has used "about 1200
+	// cycles per microsecond" without ever reading the clock, and on RPI3 this
+	// value was read here and thrown away. clockCycles1MHz cannot settle it -
+	// that is only computed inside the RPI2 branch below. Costs the loop
+	// nothing, and PICMD-LST23.LOG is the run where it would have mattered.
+	PiCMDHD::armClockHz = MaxClk;
 	RPI_PropertyInit();
 	RPI_PropertyAddTag(TAG_SET_CLOCK_RATE, ARM_CLK_ID, MaxClk);
 	RPI_PropertyProcess();
@@ -412,9 +418,9 @@ static void UpdateLCDLamps(void)
 	if (rows == 0)
 		return;
 
-	bool on[6];
-	const char* wide[6];
-	const char* narrow[6];
+	bool on[7];
+	const char* wide[7];
+	const char* narrow[7];
 
 	on[0] = true;								// POWER - the drive is running
 	on[1] = piCMDHD.IsActivityLEDOn();
@@ -422,13 +428,17 @@ static void UpdateLCDLamps(void)
 	on[3] = piCMDHD.IsWriteProtectLEDOn();
 	on[4] = piCMDHD.IsSwap8LEDOn();
 	on[5] = piCMDHD.IsSwap9LEDOn();
+	on[6] = piCMDHD.IsGeosLEDOn();
 
-	wide[0] = "POWER";   narrow[0] = "PWR";
-	wide[1] = "ACTIVE";  narrow[1] = "ACT";
-	wide[2] = "ERROR";   narrow[2] = "ERR";
-	wide[3] = "WR PROT"; narrow[3] = "WP";
-	wide[4] = "DRIVE 8"; narrow[4] = "D8";
-	wide[5] = "DRIVE 9"; narrow[5] = "D9";
+	wide[0] = "POWER"; narrow[0] = "PWR";
+	wide[1] = "ACTIV"; narrow[1] = "ACT";
+	wide[2] = "ERROR"; narrow[2] = "ERR";
+	wide[3] = "WPROT"; narrow[3] = "WP";
+	wide[4] = "DRV 8"; narrow[4] = "D8";
+	wide[5] = "DRV 9"; narrow[5] = "D9";
+	wide[6] = "GEOS";  narrow[6] = "GEO";
+
+	const int numLamps = 7;
 
 	core0RefreshingScreen.Acquire();
 	IEC_Bus::WaitMicroSeconds(100);
@@ -436,20 +446,23 @@ static void UpdateLCDLamps(void)
 	u32 lampRows;
 	if (rows >= 4)
 	{
-		// 16 characters across, so two lamps per row in eight column fields
+		// 16 characters across: three lamps per row in five column fields. Two
+		// per row read better, but seven lamps then need a fourth row, and on a
+		// four row display that is the status line underneath - which is worth
+		// more than the extra character each label would gain.
 		lampRows = 3;
-		for (int i = 0; i < 6; ++i)
+		for (int i = 0; i < numLamps; ++i)
 		{
-			snprintf(tempBuffer, tempBufferSize, "%-8s", wide[i]);
-			screenLCD->PrintText(false, (i & 1) ? 8 * 8 : 0, (i >> 1) * fontHeight,
+			snprintf(tempBuffer, tempBufferSize, "%-5s", wide[i]);
+			screenLCD->PrintText(false, (i % 3) * 5 * 8, (i / 3) * fontHeight,
 				tempBuffer, 0, on[i] ? RGBA(0xff, 0xff, 0xff, 0xff) : 0);
 		}
 	}
 	else
 	{
-		// Only room for a couple of rows: four short tags each
+		// Only room for a couple of rows: four short tags each, so seven fit
 		lampRows = 2;
-		for (int i = 0; i < 6; ++i)
+		for (int i = 0; i < numLamps; ++i)
 		{
 			snprintf(tempBuffer, tempBufferSize, "%-4s", narrow[i]);
 			screenLCD->PrintText(false, (i % 4) * 4 * 8, (i / 4) * fontHeight,
@@ -464,6 +477,14 @@ static void UpdateLCDLamps(void)
 	IEC_Bus::WaitMicroSeconds(100);
 	core0RefreshingScreen.Release();
 #endif
+}
+
+// Asked between chunks while the idle flush drains the write-back cache. The
+// bus waking up outranks finishing the backlog: whatever is left stays dirty
+// and goes out at the next quiet moment.
+static bool BusWantsTheDrive()
+{
+	return IEC_Bus::IsAtnAsserted();
 }
 
 // This runs on core0 and frees up core1 to just run the emulator.
@@ -734,6 +755,124 @@ void UpdateScreen()
 				screen.PrintText(false, 0, y - 48, tempBuffer, textColour, bgColour);
 			}
 
+			// Dirty evictions are the only way a write can reach the card
+			// while the bus is live. A stall with this at zero is a cache
+			// miss on a read; a stall with this climbing is the cache set
+			// running out of clean ways mid-transfer.
+			static u32 oldDirtyEvictions = 0xffffffff;
+			u32 dirtyEvictions = ScsiImage::DirtyEvictions();
+			if (dirtyEvictions != oldDirtyEvictions)
+			{
+				oldDirtyEvictions = dirtyEvictions;
+				snprintf(tempBuffer, tempBufferSize, "dirty evictions %u   ", dirtyEvictions);
+				screen.PrintText(false, 0, y - 64, tempBuffer, textColour, bgColour);
+			}
+
+			// How the cache is being used at all. Misses are what the card
+			// sees; hits cost nothing.
+			static u32 oldCacheReads = 0xffffffff;
+			u32 cacheHits = ScsiImage::CacheReadHits();
+			u32 cacheMisses = ScsiImage::CacheReadMisses();
+			if (cacheHits + cacheMisses != oldCacheReads)
+			{
+				oldCacheReads = cacheHits + cacheMisses;
+				snprintf(tempBuffer, tempBufferSize, "cache rd hit %u miss %u pin %uK   ",
+					cacheHits, cacheMisses, ScsiImage::PinnedKB());
+				screen.PrintText(false, 0, y - 80, tempBuffer, textColour, bgColour);
+			}
+
+			// Reads that landed on a chunk still holding unflushed writes, and
+			// the ones that also had to fetch a sector off the card into that
+			// same chunk. The second number is the one that matters: it is the
+			// only place the cache mixes what the card holds with writes that
+			// have not reached it.
+			static u32 oldDirtyChunkReads = 0xffffffff;
+			u32 dirtyChunkReads = ScsiImage::DirtyChunkReads();
+			u32 dirtyPartial = ScsiImage::DirtyChunkPartialFills();
+			if (dirtyChunkReads != oldDirtyChunkReads)
+			{
+				oldDirtyChunkReads = dirtyChunkReads;
+				snprintf(tempBuffer, tempBufferSize, "dirty-chunk rd %u partial %u   ",
+					dirtyChunkReads, dirtyPartial);
+				screen.PrintText(false, 0, y - 96, tempBuffer, textColour, bgColour);
+			}
+
+#if PICMD_ACCESS_FORENSICS
+			// Total accesses and the highest sector written. The log behind
+			// these goes to PICMD-LBA.LOG on eject; this is the summary that
+			// is readable without pulling the card.
+			static u32 oldAccessLog = 0xffffffff;
+			u32 accessLog = ScsiImage::AccessLogCount();
+			if (accessLog != oldAccessLog)
+			{
+				oldAccessLog = accessLog;
+				snprintf(tempBuffer, tempBufferSize, "accesses %u max wr lba %u   ",
+					accessLog, ScsiImage::MaxLbaWritten());
+				screen.PrintText(false, 0, y - 112, tempBuffer, textColour, bgColour);
+			}
+#else
+			// Without the forensics there is no access count to show, but the
+			// write watermark costs nothing and is the half of the line that
+			// says whether the computer got where it meant to.
+			static u32 oldMaxLba = 0xffffffff;
+			u32 maxLba = ScsiImage::MaxLbaWritten();
+			if (maxLba != oldMaxLba)
+			{
+				oldMaxLba = maxLba;
+				snprintf(tempBuffer, tempBufferSize, "max wr lba %u   ", maxLba);
+				screen.PrintText(false, 0, y - 112, tempBuffer, textColour, bgColour);
+			}
+#endif
+
+			// The SCSI data bus against what the CPU actually read off it.
+			// The corrupted bytes only ever appear in sectors the drive reads,
+			// modifies and writes back itself - never in bulk data from the
+			// computer - and always as | 0x03, so this is the join to watch:
+			// bad > 0 with xor 03 is the whole bug. ddr says which way it got
+			// in - equal to xor, a direction bit left as an output; zero, the
+			// port A latch handing back an old byte.
+			static u32 oldScsiBusReads = 0xffffffff;
+			if (PiCMDHD::scsiBusReads != oldScsiBusReads)
+			{
+				oldScsiBusReads = PiCMDHD::scsiBusReads;
+				snprintf(tempBuffer, tempBufferSize, "scsi rd %u bad %u xor %02x ddr %02x   ",
+					PiCMDHD::scsiBusReads, PiCMDHD::scsiBusMismatches,
+					PiCMDHD::scsiBusMismatchXor, PiCMDHD::scsiBusMismatchDdr);
+				screen.PrintText(false, 0, y - 160, tempBuffer, textColour, bgColour);
+
+				// Fast serial health, redrawn alongside the SCSI counter
+				// rather than when its own numbers move. These can sit at zero
+				// for an entire session, and a line that only redraws on
+				// change is indistinguishable from one that was never drawn -
+				// which is exactly how the first run read. Riding on a counter
+				// that never stops moving makes a row of zeros a result.
+				snprintf(tempBuffer, tempBufferSize, "lost %u worst %u us   ",
+					PiCMDHD::lostCycles, PiCMDHD::worstLostUs);
+				screen.PrintText(false, 0, y - 144, tempBuffer, textColour, bgColour);
+
+				// Same reasoning as the shift register line above: a counter
+				// that is meant to stay at zero cannot own its own redraw, or
+				// zero and never-drawn look identical after the screen is
+				// cleared on a disk change. This one is the whole point of the
+				// run, so it rides along too.
+				snprintf(tempBuffer, tempBufferSize, "bitrot wr %u bytes %u lba %u mask %02x   ",
+					ScsiImage::BitRotWrites(), ScsiImage::BitRotBytes(),
+					ScsiImage::BitRotFirstLba(), ScsiImage::BitRotMask());
+				screen.PrintText(false, 0, y - 176, tempBuffer, textColour, bgColour);
+			}
+
+			// Chunks written but not yet on the card - what pulling the power
+			// would throw away. It drains on its own once the bus goes quiet;
+			// ejecting forces it out.
+			static u32 oldDirtyChunks = 0xffffffff;
+			u32 dirtyChunks = ScsiImage::DirtyChunkCount();
+			if (dirtyChunks != oldDirtyChunks)
+			{
+				oldDirtyChunks = dirtyChunks;
+				snprintf(tempBuffer, tempBufferSize, "unwritten %u KB   ", dirtyChunks * 4);
+				screen.PrintText(false, 0, y - 128, tempBuffer, textColour, bgColour);
+			}
+
 			static u32 oldScanPercent = 0xffffffff;
 			if (piCMDHD.IsScanning())
 			{
@@ -907,18 +1046,133 @@ EXIT_TYPE EmulateCMDHD(FileBrowser* fileBrowser)
 	ctBefore = read32(ARM_SYSTIMER_CLO);
 #endif
 
+	// See the note beside the slow-tick gate in the loop below.
+	static const u32 SLOW_TICK_EVERY = 256;
+	u32 slowTick = 0;
+
+	// Turn on the ARM cycle counter: E|P|C set, D clear so it counts every
+	// cycle rather than every 64th, then enable PMCCNTR itself (bit 31).
+	asm volatile ("mcr p15,0,%0,c9,c12,0" :: "r" (0x07) : "memory");
+	asm volatile ("mcr p15,0,%0,c9,c12,1" :: "r" (1u << 31) : "memory");
+	#define PMCC(v) asm volatile ("mrc p15,0,%0,c9,c13,0" : "=r" (v))
+
+#if PICMD_SPLIT_CPUVIAS
+	// M2. Run once at mount, before the loop, so it costs the emulation
+	// nothing. Reads only - GPLEV0 and the system timer are both harmless to
+	// read - so this cannot disturb the drive.
+	{
+		static volatile u32 sink;
+		const u32 N = 1000;
+		u32 a, b, acc;
+
+		PMCC(a);
+		acc = 0;
+		for (u32 i = 0; i < N; i++)
+			acc += read32(ARM_GPIO_GPLEV0);
+		PMCC(b);
+		sink = acc;
+		PiCMDHD::diagReadCost[0] = (b - a) / N;
+
+		// The same filler with no read, to be subtracted.
+		PMCC(a);
+		acc = 0;
+		for (u32 i = 0; i < N; i++)
+		{
+			u32 y = i;
+			// The barrier is the point. Without it -Ofast solved this loop in
+			// closed form and the filler measured zero cycles, which quietly
+			// invalidated the two figures that depend on it.
+			for (u32 k = 0; k < 8; k++) { y = y * 3 + 1; asm volatile ("" : "+r" (y)); }
+			acc += y;
+		}
+		PMCC(b);
+		sink = acc;
+		PiCMDHD::diagReadCost[1] = (b - a) / N;
+
+		// Read issued first, filler in between, result consumed after. If the
+		// load is kept in flight this comes out near the larger of the two
+		// above rather than near their sum.
+		PMCC(a);
+		acc = 0;
+		for (u32 i = 0; i < N; i++)
+		{
+			u32 x = read32(ARM_GPIO_GPLEV0);
+			u32 y = i;
+			for (u32 k = 0; k < 8; k++) { y = y * 3 + 1; asm volatile ("" : "+r" (y)); }
+			acc += x + y;
+		}
+		PMCC(b);
+		sink = acc;
+		PiCMDHD::diagReadCost[2] = (b - a) / N;
+
+		PMCC(a);
+		acc = 0;
+		for (u32 i = 0; i < N; i++)
+			acc += read32(ARM_SYSTIMER_CLO);
+		PMCC(b);
+		sink = acc;
+		PiCMDHD::diagReadCost[3] = (b - a) / N;
+	}
+#endif
+
 	while (exitReason == EXIT_UNKNOWN)
 	{
+#if PICMD_SECTION_PROBES
+		u32 pmc0, pmc1, pmc2, pmc3, pmc4;
+		PMCC(pmc0);
+#endif
 		IEC_Bus::ReadEmulationModeCMDHD();
+#if PICMD_SECTION_PROBES
+		PMCC(pmc1);
+#endif
 
 		// The CMD HD's 65C02 runs at 2MHz; two CPU cycles per 1MHz loop.
 		for (int cycle2MHz = 0; cycle2MHz < 2; ++cycle2MHz)
 		{
+			// Look at the bus again before the second emulated cycle.
+			//
+			// The drive waits for the computer's strobe in a seven cycle poll
+			// ($0372 BIT $8000 / $0375 BEQ $0372, so every 3.5us) and then has
+			// ten cycles - 5us - to get the first symbol of a byte onto the
+			// wires. That symbol carries bits 0 and 1, and between symbols the
+			// lines are parked at a state that decodes as both of them set, so
+			// a late symbol hands the computer the byte with 0x03 ORed in:
+			// 0x00 -> 0x03 in the BAM, 0x28 -> 0x2b in the free counts,
+			// GEOS -> GGOS, a space becoming a '#'.
+			//
+			// Sampling once per emulated microsecond makes the drive see the
+			// strobe late on every byte, whether or not the loop overran - and
+			// with overruns down to 69 in 494 million, a systematic delay is
+			// all that is left to explain what still corrupts.
+			//
+			// Stated honestly, this is not "1us of latency becomes 0.5us". The
+			// poll is seven cycles, an odd number, so the cycle on which the
+			// BIT reads the port alternates parity and only half the polls can
+			// benefit. What falls is how often a poll misses the strobe
+			// outright, and a missed poll costs the whole 3.5us to the next
+			// look. Expect the corruption rate to fall by something like six
+			// times, not to zero, and measure a rate.
+			if (PICMD_SECOND_SAMPLE && cycle2MHz)
+				IEC_Bus::ReadBusInputsCMDHD();
+
+#if PICMD_SPLIT_CPUVIAS
+			u32 st0 = PiCMDArmCycles();
 			piCMDHD.m65c02.Step();
+			PiCMDHD::subCycles[0] += (u32)(PiCMDArmCycles() - st0);
+			PiCMDHD::subSamples++;
+#else
+			piCMDHD.m65c02.Step();
+#endif
 			piCMDHD.Update();
 		}
 
+#if PICMD_SECTION_PROBES
+		PMCC(pmc2);
+#endif
 		IEC_Bus::RefreshOutsCMDHD();	// Now output all outputs.
+#if PICMD_SECTION_PROBES
+		PMCC(pmc3);
+#endif
 
 		IEC_Bus::OutputLED = piCMDHD.IsActivityLEDOn();
 #if defined(RPI3)
@@ -935,6 +1189,23 @@ EXIT_TYPE EmulateCMDHD(FileBrowser* fileBrowser)
 		// drive cannot acknowledge ATN, so the computer decides it has gone
 		// away. Doing this on a timer instead landed it between SCSI commands,
 		// which is the worst possible moment.
+		// Everything from here to the end of the button handling costs 189 of
+		// the 1179 cycles this loop body was measured to use, against a
+		// microsecond budget of about 1200 on a 1.2GHz Pi 3 - 98% consumed, so
+		// there is no room for a cache miss, and 6-7% of iterations overrun.
+		// None of it needs a microsecond cadence: buttons are mechanical, the
+		// LED is for human eyes, and the idle-flush poll is a counter whose
+		// threshold can simply be scaled. Run the lot once every 256 loops,
+		// which is a quarter of a millisecond - imperceptible on a button and
+		// invisible on a lamp.
+		if ((++slowTick & (SLOW_TICK_EVERY - 1)) == 0)
+		{
+		// First, and deliberately: the RESET button handler further down does
+		// a continue out of this block, so anything placed after it would be
+		// skipped on exactly the iteration that arms the countdown it feeds.
+		// Two emulated CPU cycles per loop, SLOW_TICK_EVERY loops per visit.
+		piCMDHD.SlowTick(SLOW_TICK_EVERY * 2);
+
 		{
 			static u32 lastAccessCount = 0;
 			static u32 quietLoops = 0;
@@ -944,14 +1215,33 @@ EXIT_TYPE EmulateCMDHD(FileBrowser* fileBrowser)
 				lastAccessCount = accessCount;
 				quietLoops = 0;
 			}
-			else if (++quietLoops >= 500000)		// this loop runs at 1MHz
+			else if (++quietLoops >= 500000 / SLOW_TICK_EVERY)	// scaled: this block now runs at 1MHz/SLOW_TICK_EVERY
 			{
-				quietLoops = 0;
-				ScsiImage::FlushIdle();
+				// Drain the backlog a chunk at a time while the quiet lasts.
+				//
+				// Unbounded, this wrote everything owed inside a single loop
+				// iteration with the emulated CPU frozen throughout: 48
+				// milliseconds in one go after a GEOS installation, the worst
+				// overrun in PICMD-LST37.LOG.
+				//
+				// Now it writes one chunk per visit and says which of three
+				// things happened, because they want different answers. More
+				// to do: hold the counter at the threshold so the next slow
+				// tick, 256us away, carries straight on - a long backlog still
+				// clears promptly, but as a run of short freezes with the loop
+				// and the bus alive in between. Stopped, whether because the
+				// computer wants the drive again or because a write failed:
+				// go back to waiting the full half second. Retrying a failed
+				// write every 256us buys nothing, since FatFS latches the
+				// error and the retry never reaches the card.
+				if (ScsiImage::FlushIdle(BusWantsTheDrive) == ScsiImage::FLUSH_MORE)
+					quietLoops = 500000 / SLOW_TICK_EVERY;
+				else
+					quietLoops = 0;
 			}
 		}
 
-		IEC_Bus::ReadGPIOUserInput();
+		IEC_Bus::ReadGPIOUserInput(SLOW_TICK_EVERY);
 
 		// SWAP 8, SWAP 9 and WRITE PROTECT are momentary, just like the real
 		// front panel; HDOS samples them and decides what they mean.
@@ -1008,7 +1298,12 @@ EXIT_TYPE EmulateCMDHD(FileBrowser* fileBrowser)
 			if (exitDoAutoLoad)
 				exitReason = EXIT_AUTOLOAD;
 		}
+		}	// end slow tick
 
+		// Reset detection stays on every iteration: resetCount counts loops,
+		// so moving it inside the slow tick would silently multiply its
+		// threshold by 256, and IsReset() only reads a flag the IEC sample
+		// already set.
 		// A reset on the IEC bus resets the drive but, unlike a floppy drive
 		// in a caddy workflow, a hard drive stays attached; keep emulating.
 		bool reset = IEC_Bus::IsReset();
@@ -1036,6 +1331,17 @@ EXIT_TYPE EmulateCMDHD(FileBrowser* fileBrowser)
 			asm volatile ("mrc p15,0,%0,c9,c13,0" : "=r" (ctAfter));
 		} while ((ctAfter - ctBefore) < clockCycles1MHz);
 #else
+#if PICMD_SECTION_PROBES
+		PMCC(pmc4);
+		PiCMDHD::sectionCycles[0] += (u32)(pmc1 - pmc0);
+		PiCMDHD::sectionCycles[1] += (u32)(pmc2 - pmc1);
+		PiCMDHD::sectionCycles[2] += (u32)(pmc3 - pmc2);
+		PiCMDHD::sectionCycles[3] += (u32)(pmc4 - pmc3);
+#endif
+		// Not behind the switch: this is the denominator of the overrun rate,
+		// which is the drive's health meter and has to keep working in a build
+		// nobody is measuring.
+		PiCMDHD::loopIterations++;
 		do	// Sync to the 1MHz clock
 		{
 			ctAfter = read32(ARM_SYSTIMER_CLO);
@@ -1044,7 +1350,10 @@ EXIT_TYPE EmulateCMDHD(FileBrowser* fileBrowser)
 			{
 				// If this ever occurs then we have taken too long (ie >1us) and lost a cycle.
 				// Cycle accuracy is now in jeopardy. If this occurs during critical communication loops then emulation can fail!
-				//DEBUG_LOG("!");
+				PiCMDHD::lostCycles++;
+				PiCMDHD::lostHist[ct < 16 ? ct : 15]++;
+				if (ct > PiCMDHD::worstLostUs)
+					PiCMDHD::worstLostUs = ct;
 			}
 		} while (ctAfter == ctBefore);
 #endif
@@ -1124,12 +1433,14 @@ void emulator()
 
 			inputMappings->WaitForClearButtons();
 
-#if not defined(EXPERIMENTALZERO)
-			core0RefreshingScreen.Release();
-#endif
+			// No Release here. This core never acquired core0RefreshingScreen
+			// on the way into emulation, and SpinLock::Release just stores zero
+			// without checking ownership - so releasing it here handed the lock
+			// away while core 0 was still inside a refresh, putting both cores
+			// in the framebuffer and, worse, in the middle of the same I2C
+			// transaction to the LCD.
 		}
 	}
-	delete fileBrowser;
 }
 
 //static void MouseHandler(unsigned nButtons,
@@ -1253,6 +1564,8 @@ void DisplayOptions(int y_pos)
 	screen.PrintText(false, 0, y_pos += 16, tempBuffer, COLOUR_WHITE, COLOUR_BLACK);
 	snprintf(tempBuffer, tempBufferSize, "LcdLogoName = %s\r\n", options.GetLcdLogoName());
 	screen.PrintText(false, 0, y_pos += 16, tempBuffer, COLOUR_WHITE, COLOUR_BLACK);
+	snprintf(tempBuffer, tempBufferSize, "CMDHDCacheMB = %d\r\n", options.GetCMDHDCacheMB());
+	screen.PrintText(false, 0, y_pos += 16, tempBuffer, COLOUR_WHITE, COLOUR_BLACK);
 #endif
 }
 
@@ -1356,8 +1669,36 @@ static void CheckOptions()
 
 	// Options for the CMD HD emulation itself.
 	piCMDHD.SetForcedDeviceID((u8)options.GetCMDHDDeviceID());
-	ScsiImage::InitCache(options.GetCMDHDCacheMB() * 1024 * 1024);
+	piCMDHD.SetPreloadMB(options.GetCMDHDPreloadMB());
+	// Clamp before converting to bytes: the multiply is 32 bit, so 4096 lands on
+	// exactly 2^32 and comes out as zero - which InitCache would round up to its
+	// 16 slot floor and leave a 64KB cache, the worst possible outcome for a
+	// setting someone raised on purpose. Anything above the cap cannot fit under
+	// the heap ceiling anyway, and InitCache halves its way down from there.
+	u32 cacheMB = options.GetCMDHDCacheMB();
+	if (cacheMB > 512)
+		cacheMB = 512;
+	ScsiImage::InitCache(cacheMB * 1024 * 1024);
 	EMMCBlockingWaitHook = ServiceIECWhileCardBusy;
+
+#if not defined(EXPERIMENTALZERO)
+	// Say how much cache was actually obtained. DEBUG_LOG is compiled out of a
+	// release build, so this used to be invisible - and no cache at all means
+	// every sector access stalls the drive on the card.
+	{
+		u32 cacheKB = ScsiImage::CacheSizeKB();
+		if (cacheKB == 0)
+		{
+			snprintf(tempBuffer, tempBufferSize, "WARNING: no CMD HD disk cache (allocation failed)");
+			screen.PrintText(false, 0, heightScreen - 32, tempBuffer, COLOUR_WHITE, COLOUR_RED);
+		}
+		else if (options.ShowOptions())
+		{
+			snprintf(tempBuffer, tempBufferSize, "CMD HD disk cache = %u KB", cacheKB);
+			screen.PrintText(false, 0, heightScreen - 32, tempBuffer, COLOUR_WHITE, COLOUR_BLACK);
+		}
+	}
+#endif
 
 	inputMappings->INPUT_BUTTON_ENTER = options.GetButtonEnter();
 	inputMappings->INPUT_BUTTON_UP = options.GetButtonUp();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -25,6 +25,15 @@
 
 #define INVALID_VALUE	((unsigned) -1)
 
+// strncpy leaves the destination unterminated when the source fills it. The
+// string options all copy into 256 byte members, and only survived that by
+// accident: Options is a global, so .bss had already zeroed the last byte.
+static void CopyStringOption(char* dest, size_t size, const char* value)
+{
+	strncpy(dest, value, size - 1);
+	dest[size - 1] = 0;
+}
+
 char* TextParser::GetToken(bool includeSpace)
 {
 	bool isSpace;
@@ -122,7 +131,8 @@ bool TextParser::ParseComment()
 Options::Options(void)
 	: TextParser()
 	, CMDHDDeviceID(0)
-	, CMDHDCacheMB(32)
+	, CMDHDCacheMB(24)
+	, CMDHDPreloadMB(18)
 	, CMDHDAtnOutGPIO(0)
 	, CMDHDLcdLamps(1)
 	, onResetChangeToStartingFolder(0)
@@ -189,13 +199,19 @@ void Options::Process(char* buffer)
 		/*char* equals = */GetToken();
 		char* pValue = GetToken();
 
+		// A name with no value at the end of the file. Every branch below reads
+		// it, and strcasecmp/strncpy on a null pointer would take the Pi down
+		// before it ever showed the boot screen.
+		if (pValue == 0)
+			break;
+
 		if ((strcasecmp(pOption, "Font") == 0) || (strcasecmp(pOption, "ChargenFont") == 0))
 		{
-			strncpy(ROMFontName, pValue, 255);
+			CopyStringOption(ROMFontName, sizeof(ROMFontName), pValue);
 		}
 		else if ((strcasecmp(pOption, "AutoMountImage") == 0))
 		{
-			strncpy(autoMountImageName, pValue, 255);
+			CopyStringOption(autoMountImageName, sizeof(autoMountImageName), pValue);
 		}
 		ELSE_CHECK_DECIMAL_OPTION(onResetChangeToStartingFolder)
 		ELSE_CHECK_DECIMAL_OPTION(supportUARTInput)
@@ -232,11 +248,11 @@ void Options::Process(char* buffer)
 		ELSE_CHECK_DECIMAL_OPTION(CMDHDButtonExit)
 		else if ((strcasecmp(pOption, "LCDLogoName") == 0))
 		{
-			strncpy(LcdLogoName, pValue, 255);
+			CopyStringOption(LcdLogoName, sizeof(LcdLogoName), pValue);
 		}
 		else if ((strcasecmp(pOption, "LCDName") == 0))
 		{
-			strncpy(LCDName, pValue, 255);
+			CopyStringOption(LCDName, sizeof(LCDName), pValue);
 			if (strcasecmp(pValue, "ssd1306_128x64") == 0)
 				i2cLcdModel = LCD_1306_128x64;
 			else if (strcasecmp(pValue, "ssd1306_128x32") == 0)
@@ -246,10 +262,11 @@ void Options::Process(char* buffer)
 		}
 		else if ((strcasecmp(pOption, "CMDHDRomName") == 0) || (strcasecmp(pOption, "ROMCMDHD") == 0))
 		{
-			strncpy(ROMNameCMDHD, pValue, 255);
+			CopyStringOption(ROMNameCMDHD, sizeof(ROMNameCMDHD), pValue);
 		}
 		ELSE_CHECK_DECIMAL_OPTION(CMDHDDeviceID)
 		ELSE_CHECK_DECIMAL_OPTION(CMDHDCacheMB)
+		ELSE_CHECK_DECIMAL_OPTION(CMDHDPreloadMB)
 		ELSE_CHECK_DECIMAL_OPTION(CMDHDAtnOutGPIO)
 		ELSE_CHECK_DECIMAL_OPTION(CMDHDLcdLamps)
 	}
@@ -265,16 +282,44 @@ void Options::Process(char* buffer)
 unsigned Options::GetDecimal(char* pString)
 {
 	if (pString == 0 || *pString == '\0')
-		return 0;
+		return INVALID_VALUE;
 
-	return strtol(pString, NULL, 0);
+	// Report anything that is not a whole non-negative number as invalid so the
+	// option keeps its default. This used to hand back strtol's zero for input
+	// it could not parse at all, which turned a typo into a silent setting of
+	// zero - and made the INVALID_VALUE check at every call site dead code.
+	char* end = 0;
+	long value = strtol(pString, &end, 0);
+
+	if (end == pString || value < 0)
+		return INVALID_VALUE;
+
+	while (*end == ' ' || *end == '\t' || *end == '\r' || *end == '\n')
+		end++;
+	if (*end != '\0')
+		return INVALID_VALUE;
+
+	return (unsigned)value;
 }
 
 float Options::GetFloat(char* pString)
 {
+	// Same contract as GetDecimal: unparseable input has to be distinguishable
+	// from a real zero, or a typo silently becomes a setting of zero.
 	if (pString == 0 || *pString == '\0')
-		return 0;
+		return (float)INVALID_VALUE;
 
-	return atof(pString);
+	char* end = 0;
+	float value = strtof(pString, &end);
+
+	if (end == pString)
+		return (float)INVALID_VALUE;
+
+	while (*end == ' ' || *end == '\t' || *end == '\r' || *end == '\n')
+		end++;
+	if (*end != '\0')
+		return (float)INVALID_VALUE;
+
+	return value;
 }
 

--- a/src/options.h
+++ b/src/options.h
@@ -52,6 +52,10 @@ public:
 	inline const char* GetRomNameCMDHD() const { return ROMNameCMDHD; }
 	inline unsigned int GetCMDHDDeviceID() const { return CMDHDDeviceID; }
 	inline unsigned int GetCMDHDCacheMB() const { return CMDHDCacheMB; }
+	// Megabytes of the image read into the cache at mount, before the computer
+	// can ask for anything. Those chunks are pinned: they cannot be evicted, so
+	// they never cost an SD access again. 0 disables it.
+	inline unsigned int GetCMDHDPreloadMB() const { return CMDHDPreloadMB; }
 	// GPIO used to pull the IEC ATN line low (0 = the drive cannot drive ATN).
 	// 24 on a Pi1541io: its ATN level shifter is bidirectional, so the pin that
 	// reads ATN can drive it too.
@@ -116,6 +120,7 @@ public:
 private:
 	unsigned int CMDHDDeviceID;
 	unsigned int CMDHDCacheMB;
+	unsigned int CMDHDPreloadMB;
 	unsigned int CMDHDAtnOutGPIO;
 	unsigned int CMDHDLcdLamps;
 	unsigned int onResetChangeToStartingFolder;

--- a/src/picmd_switches.h
+++ b/src/picmd_switches.h
@@ -1,0 +1,51 @@
+// Pi-CMD build switches.
+//
+// They live in their own header, included from types.h, for a reason that cost
+// an afternoon twice. They were first put in picmdhd.h, where m6522.h could not
+// see them, so the VIA counters silently compiled to nothing and the build only
+// broke because a caller referenced them. Moving them to m65c02.h fixed that
+// and broke scsi.h the same way - scsi.h does not include m65c02.h - so
+// PICMD_ACCESS_FORENSICS evaluated to 0 there whatever it was set to, and the
+// "off" build was right by accident rather than by construction.
+//
+// An #if on a macro the translation unit cannot see is not a switch. It is a
+// deletion wearing a switch's clothes. types.h is included by everything, so
+// this is the one place they cannot go wrong.
+//
+// After changing any of these: touch the .cpp files or build clean. The
+// Makefile tracks no header dependencies, so editing a header alone relinks
+// the previous objects and produces a kernel that does not contain the change.
+
+#ifndef PICMD_SWITCHES_H
+#define PICMD_SWITCHES_H
+
+// Diagnostic split of the emulation cost: per-section cycle attribution inside
+// cpu+vias, the sticky VIA idle bits, and the blocking-read micro-benchmark.
+// Off in anything you would deploy.
+#define PICMD_SPLIT_CPUVIAS 0
+
+// Bisection switches. Both default on; turning one off builds an earlier stage
+// from the SAME source, so the three test kernels differ only in the change
+// under test and not in their instrumentation. Comparing logs between builds
+// that differ in more than one thing is how this investigation lost a week.
+//   1 = skip an idle VIA in m6522::Execute
+#define PICMD_VIA_IDLE_SKIP 1
+//   1 = take the trimmed second look at the bus between the emulated cycles
+#define PICMD_SECOND_SAMPLE 1
+
+// Access forensics: the per-access address log and the payload ring, with the
+// PICMD-LBAnn.LOG and PICMD-WRnn.LOG dumps they feed. They cost 256KB of BSS -
+// accessLog and writeLogData are 128KB each, together 47% of the kernel's BSS
+// and the largest objects in it - and that comes straight out of the heap the
+// disk cache draws on. Off unless a run needs to know what the computer asked
+// for, which is a debugging question and not a running one.
+#define PICMD_ACCESS_FORENSICS 0
+
+// Section attribution of the emulation loop: five coprocessor reads and four
+// 64 bit accumulations per iteration, measured at about 30 cycles against a
+// budget of 1200. The cheap counters - the overrun count, the histogram, the
+// worst case - stay compiled in either way, because they are the drive's
+// health meter and they only run on an iteration that already overran.
+#define PICMD_SECTION_PROBES 0
+
+#endif

--- a/src/rpi/armc-cstubs.c
+++ b/src/rpi/armc-cstubs.c
@@ -64,6 +64,7 @@ extern int errno;
 
 /* Prototype for the UART write function */
 #include "rpi-aux.h"
+#include "cache.h"
 
 /* A pointer to a list of environment variables and their values. For a minimal
  environment, this empty list is adequate: */
@@ -200,6 +201,29 @@ caddr_t _sbrk(int incr)
 
   if (heap_end == 0)
     heap_end = &_end;
+
+  /* This used to hand out memory unconditionally, which meant malloc could
+     never fail: it returned a pointer no matter how much was asked for, and
+     the caller then used memory that either does not exist or - worse - sits
+     above UNCACHED_MEM_BASE, where the page tables mark RAM as uncacheable.
+     A large CMD HD disk cache landed there and every access to it went to
+     bare SDRAM with no L1/L2 behind it.
+
+     Cap the heap at the top of cacheable RAM and report failure properly, so
+     an oversized request degrades into a smaller allocation instead of
+     silently corrupting or crawling. */
+  /* Stop below the exception vectors, not at the top of cacheable RAM. The
+     vector page is copied to HIGH_VECTORS_BASE at boot and VBAR points at it
+     for good (see cache.c), yet it sits right in the middle of where a large
+     heap lands: with _end near 31MB, a 64MB disk cache runs straight over it.
+     Nothing would fail at allocation time - the drive would simply die the
+     first time a cached chunk landed on that page and an interrupt vectored
+     into it. */
+  if (incr > 0 && (unsigned)(heap_end + incr) > (unsigned)HIGH_VECTORS_BASE)
+  {
+    errno = ENOMEM;
+    return (caddr_t) -1;
+  }
 
   prev_heap_end = heap_end;
   heap_end += incr;

--- a/src/rpi/emmc.cpp
+++ b/src/rpi/emmc.cpp
@@ -1979,37 +1979,44 @@ int CEMMCDevice::DoWrite(u8 *buf, size_t buf_size, u32 block_no)
 
 void (*EMMCBlockingWaitHook)(void) = 0;
 
+// How often the blocking-wait hook gets a turn, in microseconds. The point of
+// the hook is to keep the serial bus alive while the card is busy, and the bus
+// tolerates being ignored for far longer than this.
+#define EMMC_HOOK_INTERVAL_US 100
+
 int CEMMCDevice::TimeoutWait(unsigned reg, unsigned mask, int value, unsigned usec)
 {
-	unsigned nCount = usec / 1000;
+	// Poll as fast as the peripheral will answer. This used to sleep a whole
+	// millisecond between looks, which kept the overall timeout right but made
+	// every wait cost a millisecond even when the card was ready in tens of
+	// microseconds - and a single block transfer goes through several of them
+	// (command complete, data ready per block, transfer complete). That, not
+	// the card, was most of the tens of milliseconds an SD access was measured
+	// at, and everything above this driver is built to work around that number.
+	unsigned start = read32(ARM_SYSTIMER_CLO);
+	unsigned lastService = start;
 
-	do
+	for (;;)
 	{
-		delay_us(1);
-
 		if ((read32(reg) & mask) ? value : !value)
 		{
 			return 0;
 		}
 
-		// Wait out the rest of the millisecond in short steps, giving whoever
-		// registered the hook a chance to keep the outside world serviced.
-		// Without this the emulated drive goes deaf for the whole access and
-		// the computer decides it has been unplugged.
-		if (EMMCBlockingWaitHook)
+		unsigned now = read32(ARM_SYSTIMER_CLO);
+
+		if (now - start >= usec)
 		{
-			for (int i = 0; i < 10; ++i)
-			{
-				EMMCBlockingWaitHook();
-				delay_us(99);
-			}
+			return -1;
 		}
-		else
+
+		// Give whoever registered the hook a turn. Without this the emulated
+		// drive goes deaf for the whole access and the computer decides it has
+		// been unplugged.
+		if (EMMCBlockingWaitHook && (now - lastService) >= EMMC_HOOK_INTERVAL_US)
 		{
-			delay_us(999);
+			lastService = now;
+			EMMCBlockingWaitHook();
 		}
 	}
-	while(nCount--);
-
-	return -1;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <uspi/types.h>
 #include "integer.h"
+#include "picmd_switches.h"
 
 typedef unsigned long long	u64;
 

--- a/src/ui/filebrowser.cpp
+++ b/src/ui/filebrowser.cpp
@@ -837,14 +837,19 @@ bool FileBrowser::CheckForPNG(const char* filename, FILINFO& filIcon)
 		char* ptr = strrchr(filename, '.');
 		if (ptr)
 		{
-			int len = ptr - filename;
-			strncpy(fileName, filename, len);
-			fileName[len] = 0;
+			// Long file names are on (_MAX_LFN is 255), so the stem can be as
+			// long as this buffer on its own. It has to leave room for ".png"
+			// and the terminator, and a name that does not is simply one we
+			// cannot have an icon for.
+			size_t len = (size_t)(ptr - filename);
+			if (len + sizeof(".png") <= sizeof(fileName))
+			{
+				memcpy(fileName, filename, len);
+				strcpy(fileName + len, ".png");
 
-			strcat(fileName, ".png");
-
-			if (f_stat(fileName, &filIcon) == FR_OK)
-				foundValid = true;
+				if (f_stat(fileName, &filIcon) == FR_OK)
+					foundValid = true;
+			}
 		}
 	}
 	return foundValid;


### PR DESCRIPTION
## Problem

GEOS/GDOS64 on a C64 read intermittently corrupted bytes from the emulated CMD HD:
partition names as `GGOS` or `GDOS###`, stray `#` in filenames, phantom directory
entries, and a GDOS installation that stopped partway with `error $05`. The same
installation against any other device, including a real 1581, worked.

## Mechanism

The drive sends a byte as four two-bit symbols, no handshake. It polls for the
computer's strobe in a seven cycle loop (`$0372 BIT $8000` / `$0375 BEQ $0372`,
every 3.5us at 2MHz) and then has ten cycles — 5us — to put the first symbol on
the wires (`$0377 LDA $0300,X` / `$037a STA $8000`).

Symbol 1 carries **bits 0 and 1** of the byte. Between symbols the lines sit
parked at the value from `$036d LDA #$04`, and the nibble table at `$0300` maps a
symbol to the complement of its bits — so the parked state decodes as **both of
those bits set**. A late symbol 1 hands the computer the byte with `0x03` ORed in.

| observed | explanation |
|---|---|
| `0x00` → `0x03` in the BAM | `0x00 \| 0x03` |
| `0x28` → `0x2b` in free-block counts | `0x28 \| 0x03` |
| `GEOS` → `GGOS` | `'E'` = `0x45` → `0x47` = `'G'` |
| `' '` → `'#'` in filenames | `0x20` → `0x23` |
| `GD.DISK.RAMNM` → `GD.DISK.RAMNO` | `'M'` = `0x4d` → `0x4f` = `'O'` |

The last row is `error $05`: the installer looks for a file whose name the
corruption changed, and GEOS reports `FILE_NOT_FOUND`.

Two sources of delay:

1. The 1MHz emulation loop was using 1179 of its ~1200 ARM cycles and overran
   6-7% of iterations, with no catch-up.
2. Bus inputs were sampled once per emulated microsecond, so the drive saw the
   strobe late on **every** byte regardless of overruns. This is what remained
   after (1) was fixed — a run with 69 overruns in 494M iterations still
   corrupted data.

## Fix

- Drive the bus outputs when the CPU writes the port, not at end of microsecond.
- Sample the bus again between the two emulated CPU cycles, using a **snapshot**
  of the drive's own output flags — a live guard re-reads a line the drive has
  only just released, before it has finished rising, which is worse than no fix.
- Pay for it by taking work out of the emulated cycle: LEDs/buttons/keyboard and
  the idle-flush poll to a 256-iteration tick, the RTC and button countdowns with
  them, CB1/CB2 level guards, an early-out for an idle VIA, and removal of a PB6
  edge test that compared a `0x40`-masked value against `1` and could never fire.

## Also in this branch

- Cache bounded to available ARM RAM; its front pinned at mount so BAM and
  directory are never evicted.
- **Data loss fixed.** `FlushChunk` leaves `dirtyMask` set when a write does not
  land; three callers discarded that, so `Detach` invalidated slots holding
  sectors the card had refused. The failure now propagates, and what cannot be
  written is counted and reported at eject.
- The idle flush wrote the whole backlog inside one loop iteration — 48ms
  measured, drive unable to answer ATN throughout. Now one chunk per visit,
  resuming on the next tick while the bus stays quiet.
- Diagnostic instrumentation moved behind switches in `src/picmd_switches.h`,
  off by default: 264,200 bytes of BSS and ~30 cycles/us returned.
- `README.md` / `options.txt` said write-through for a write-back cache,
  documented a 128MB default against 24 in code, omitted `CMDHDPreloadMB`, and
  never mentioned ejecting before power-off.

## Verified on hardware

Raspberry Pi 3 @ 1.2GHz, Ultimate64, against a clean baseline image.

| | before | after |
|---|---|---|
| GDOS64 installation | fails, `error $05` | completes, no errors (x2) |
| corrupt bytes in image | 4 | **0** |
| loop overruns (comparable install) | 13,976 | 257 |
| worst overrun | 48,872us | 4,963us |
| longest single card access | — | 4,959us |
| unflushed sectors at detach | not detected | 0 |

The last two rows are the same event: the longest loop overrun is now exactly one
card access, so the batching is gone and what remains is the card's own latency.

Corruption was measured three ways, each with a control that stays clean on the
baseline: a byte-level bit-gain census, BAM self-consistency (free-block count vs
population count of its own bitmap), and filename sibling series
(`GD.DISK.FD41/FD71/FD81/FDNM` and friends, where the odd one out is the damaged
member).

## Reviewing

Squashed to one commit; the commit message carries the same detail. Build with
the Arm GNU toolchain (not homebrew's — no newlib). Note the Makefile tracks no
header dependencies: `touch` the `.cpp` files or build clean after editing a
header.
